### PR TITLE
Basic yaml-api validation

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+#### GENERAL CONFIG ####
+# level of logging (1=debug, 2=info, 3=warn, 4=error)
+LOG_LEVEL=2

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 #### GENERAL CONFIG ####
-# level of logging (1=debug, 2=info, 3=warn, 4=error)
+# level of logging (1=debug, 2=info, 3=warn, 5=error)
 LOG_LEVEL=2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# virtual environment
+validator
+
+# junk folder
+__pycache__
+
+# yamls
+*.yaml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# itm-scenario-validator
+# ITM Scenario Validator
+
+## Getting Started
+
+### Creating a Virtual Environment
+```
+python3.8 -m venv validator
+```
+Note: You may have to install venv tools on your system. For linux, the command is
+```
+sudo apt install python3.8-venv
+```
+
+To activate the virtual environment:
+
+**Windows:**
+```
+validator\Scripts\activate
+```
+
+**MacOS/Linux:**
+```
+source validator/bin/activate
+```
+
+You are now in a virtual environment where you can install the requirements and run the main script.
+
+To deactivate the environment, run
+```
+deactivate
+```
+
+### Installing from Requirements
+```
+pip install -r requirements.txt
+```
+
+## Running the Program
+To run the validator, execute the following command:
+```
+python3 validator.py -f [path_to_file]
+```
+Ensure that the path leads to a yaml file
+
+## Logging
+To change the log level, edit the value in the .env file.

--- a/api.py
+++ b/api.py
@@ -1,0 +1,172 @@
+'''
+    A collection of expected elements at each level of the yaml file.
+    https://nextcentury.atlassian.net/wiki/spaces/ITMC/pages/3041951763/Scenario+YAML+Documentation#Condition-level-elements
+'''
+
+### TODO: change each to have {type: [type], required: [bool], list: [bool], min: [float], max: [float], allowed_vals: [list]}
+
+MISSION_LEVEL = {
+    'unstructured': str,
+    'mission_type': str,
+    'critical_ids': list,
+    'civilian_presence': str,
+    'communication_capability': str,
+    'roe': str,
+    'political_climate': str,
+    'medical_policies': str
+}
+
+SIM_ENVIRONMENT_LEVEL = {
+    'type': str,
+    'terrain': str,
+    'weather': str,
+    'lighting': str,
+    'visibility': str,
+    'noise_ambient': str,
+    'noise_peak': str,
+    'temperature': float,
+    'humidity': float,
+    'flora': str,
+    'fauna': str
+}
+
+AID_LEVEL = {
+    'delay': float, # must be positive
+    'type': str,
+    'max_transport': int # must be positive
+}
+
+DECISION_ENVIRONMENT_LEVEL = {
+    'unstructured': str,
+    'aid_delay': AID_LEVEL,
+    'movement_restriction': str,
+    'sound_restriction': str,
+    'oxygen_levels': str,
+    'population_density': float,
+    'injury_triggers': str,
+    'air_quality': int,
+    'city_infrastructure': str
+}
+
+ENVIRONMENT_LEVEL = {
+    'sim-environment': SIM_ENVIRONMENT_LEVEL,
+    'decision-environment': DECISION_ENVIRONMENT_LEVEL
+}
+
+THREAT_LEVEL = {
+    'unstructured': str,
+    'threats': list
+}
+
+
+SUPPLY_LEVEL = {
+    'type': str,
+    'quantity': float, # 0-999
+    'reusable': bool
+}
+
+DEMOGRAPHIC_LEVEL = {
+    'age': float, # positive
+    'sex': str,
+    'race': str,
+    'military_disposition': str,
+    'military_branch': str,
+    'rank': str,
+    'rank_title': str,
+    'skills': dict,
+    'role': str,
+    'mission_importance': str
+}
+
+VITAL_LEVEL = {
+    'conscious': bool,
+    'avpu': str,
+    'mental_status': str,
+    'breathing': str,
+    'hrpmin': float, # must be positive
+    'Spo2': float # must be positive
+}
+ 
+INJURY_LEVEL = {
+  'name': str,
+  'location': str,
+  'severity': float, # 0.0-1.0
+  'hidden': bool
+}
+
+CHARACTER_LEVEL = {
+    'id': str,
+    'name': str,
+    'unstructured': str,
+    'unstructured_postassess': str,
+    'rapport': float, # 0-10
+    'demographics': DEMOGRAPHIC_LEVEL,
+    'vitals': VITAL_LEVEL,
+    'injuries': INJURY_LEVEL
+}
+
+STATE_LEVEL = {
+    'unstructured': str,
+    'mission': MISSION_LEVEL,
+    'environment': ENVIRONMENT_LEVEL,
+    'threat_state': THREAT_LEVEL,
+    'supplies': SUPPLY_LEVEL,
+    'characters': CHARACTER_LEVEL
+}
+
+CONDITION_LEVEL = {
+    'elapsed_time_lt': int, # positive
+    'elapsed_time_gt': int, # positive
+    'actions': list, # list of lists
+    'probes': bool,
+    'probe_responses': bool, # not a list of bools?
+    'character_vitals': list, # TODO: update this
+    'supplies': list # TODO: update this
+}
+
+ACTION_LEVEL = {
+    'id': str,
+    'type': str,
+    'unstructured': str,
+    'repeatable': bool,
+    'character_id': str,
+    'parameters': str, # what is this? dict? what properties are allowed?
+    'probe_id': str,
+    'choice': str,
+    'kdma_association': dict, # TODO: this is key-value (Fairness: 8)
+    'condition_semantics': str,
+    'conditions': CONDITION_LEVEL
+}
+
+TAGGING_LEVEL = {
+    'enabled': bool,
+    'repeatable': bool,
+    'probe_responses': list,
+    'reference': str # or int?
+}
+
+PROBE_LEVEL = {
+    'character_id': str,
+    'probe_id': str,
+    'minimal': str,
+    'delayed': str,
+    'immediate': str,
+    'expectant': str
+}
+
+SCENE_LEVEL = {
+    'index': int,
+    'state': STATE_LEVEL, # TODO: not the same type of state I think
+    'end_scenario_allowed': bool,
+    'tagging': TAGGING_LEVEL,
+    'actions': ACTION_LEVEL,
+    'transition_semantics': str,
+    'transitions': CONDITION_LEVEL
+}
+
+TOP_LEVEL = {
+    'id': str,
+    'name': str,
+    'state': STATE_LEVEL,
+    'scenes': SCENE_LEVEL
+}

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,35 @@
+from enum import Enum
+from decouple import config
+
+class LogLevel(Enum):
+    DEBUG = 1
+    INFO = 2
+    WARN = 3
+    ERROR = 4
+    CRITICAL_INFO = float('inf')
+
+class Logger:
+    calling_class = None
+    def __init__(self, caller):
+        self.calling_class = caller
+
+    def log(self, log_level, msg):
+        '''
+        If the log level is equal to or greater than the global config for logging, 
+        print the message with an appropriate prefix
+        '''
+        if log_level.value >= int(config('LOG_LEVEL')):
+            premsg = ''
+            if (log_level == LogLevel.DEBUG):
+                premsg = "\033[90mDebug (" + self.calling_class + "):\t"
+            if (log_level == LogLevel.INFO):
+                premsg = "\033[37mInfo (" + self.calling_class + "):\t"
+            if (log_level == LogLevel.WARN):
+                premsg = "\033[93mWarn (" + self.calling_class + "):\t"
+            if (log_level == LogLevel.ERROR):
+                premsg = "\033[91mError (" + self.calling_class + "):\t"
+                print(premsg, msg, '\033[0m', flush=True)
+                exit(1)
+            if (log_level == LogLevel.CRITICAL_INFO):
+                premsg = "\033[36mInfo (" + self.calling_class + "):\t"
+            print(premsg, msg, '\033[0m', flush=True)

--- a/logger.py
+++ b/logger.py
@@ -4,8 +4,9 @@ from decouple import config
 class LogLevel(Enum):
     DEBUG = 1
     INFO = 2
-    WARN = 3
-    ERROR = 4
+    MINOR_WARN = 3
+    SEVERE_WARN = 4
+    ERROR = 5
     CRITICAL_INFO = float('inf')
 
 class Logger:
@@ -24,7 +25,9 @@ class Logger:
                 premsg = "\033[90mDebug (" + self.calling_class + "):\t"
             if (log_level == LogLevel.INFO):
                 premsg = "\033[37mInfo (" + self.calling_class + "):\t"
-            if (log_level == LogLevel.WARN):
+            if (log_level == LogLevel.MINOR_WARN):
+                premsg = "\033[35mWarn (" + self.calling_class + "):\t"
+            if (log_level == LogLevel.SEVERE_WARN):
                 premsg = "\033[93mWarn (" + self.calling_class + "):\t"
             if (log_level == LogLevel.ERROR):
                 premsg = "\033[91mError (" + self.calling_class + "):\t"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-decouple==3.8
+PyYAML==6.0

--- a/validator.py
+++ b/validator.py
@@ -2,7 +2,6 @@ import argparse
 import yaml
 from api import TOP_LEVEL
 from logger import LogLevel, Logger
-# import json 
 
 class YamlValidator:
     logger = Logger("yamlValidator")
@@ -16,7 +15,6 @@ class YamlValidator:
         self.file = self.validate_file_location(filename)
         try:
             self.loadedYaml = yaml.load(self.file, Loader=yaml.CLoader)
-            # print(json.dumps(self.loadedYaml, indent=4))
         except Exception as e:
             self.logger.log(LogLevel.ERROR, "Error while loading in yaml file. Please ensure the file is a valid yaml format and try again.\n\n" + str(e) + "\n")
     
@@ -44,11 +42,11 @@ class YamlValidator:
             try:
                 for key in to_validate:
                     if key in found_keys:
-                        self.logger.log(LogLevel.WARN, "'" + key + "' is duplicated at the " + level_name + " level of the yaml file")
+                        self.logger.log(LogLevel.SEVERE_WARN, "'" + key + "' is duplicated at the " + level_name + " level of the yaml file")
                         is_valid = False
                     # check if the key is expected
                     if key not in typed_keys:
-                        self.logger.log(LogLevel.WARN, "'" + key + "' is not a valid key at the " + level_name + " level of the yaml file. Allowed keys are " + str(typed_keys.keys()))
+                        self.logger.log(LogLevel.SEVERE_WARN, "'" + key + "' is not a valid key at the " + level_name + " level of the yaml file. Allowed keys are " + str(typed_keys.keys()))
                         is_valid = False
                     else:
                         # check type of object
@@ -56,15 +54,15 @@ class YamlValidator:
                             if not self.validate_sublevel(key, to_validate[key], typed_keys[key]):
                                 is_valid = False
                         # check basic type (string, int, etc)
-                        elif not (isinstance(to_validate[key], typed_keys[key]) or (type(typed_keys[key]) == type(float) and isinstance(to_validate[key], int))):
-                            self.logger.log(LogLevel.WARN, "'" + key + "' should be type " + str(typed_keys[key]) + " but is " + str(type(to_validate[key])) + " instead.")
+                        elif not (isinstance(to_validate[key], typed_keys[key]) or (typed_keys[key] == float and isinstance(to_validate[key], int))):
+                            self.logger.log(LogLevel.SEVERE_WARN, "'" + key + "' should be type " + str(typed_keys[key]) + " but is " + str(type(to_validate[key])) + " instead.")
                             is_valid = False
                     found_keys.append(key)
             except:
-                self.logger.log(LogLevel.WARN, "'" + key + "' does not have a defined type at the " + level_name + " level of the yaml file")
+                self.logger.log(LogLevel.SEVERE_WARN, "'" + key + "' does not have a defined type at the " + level_name + " level of the yaml file")
             for key in typed_keys:
                 if key not in found_keys:
-                    self.logger.log(LogLevel.WARN, "'" + key + "' is missing at the " + level_name + " level of the yaml file")
+                    self.logger.log(LogLevel.MINOR_WARN, "'" + key + "' is missing at the " + level_name + " level of the yaml file")
                     is_valid = False
         return is_valid
 
@@ -101,8 +99,9 @@ if __name__ == '__main__':
     validator = YamlValidator(file)
     # validate the field names in the valid
     field_names_valid = validator.validate_field_names()
-    # print the answer for validity
+    # print the answer for validity (after a new line for better readability)
+    print("")
     if field_names_valid:
-        validator.logger.log(LogLevel.CRITICAL_INFO, file + " is valid!")
+        validator.logger.log(LogLevel.CRITICAL_INFO, "\033[93m" + file + " is valid!")
     else:
-        validator.logger.log(LogLevel.CRITICAL_INFO, file + " is not valid.")
+        validator.logger.log(LogLevel.CRITICAL_INFO, "\033[91m" + file + " is not valid.")

--- a/validator.py
+++ b/validator.py
@@ -1,0 +1,108 @@
+import argparse
+import yaml
+from api import TOP_LEVEL
+from logger import LogLevel, Logger
+# import json 
+
+class YamlValidator:
+    logger = Logger("yamlValidator")
+    file = None
+    loadedYaml = None
+
+    def __init__(self, filename):
+        '''
+        Load in the file and parse the yaml
+        '''
+        self.file = self.validate_file_location(filename)
+        try:
+            self.loadedYaml = yaml.load(self.file, Loader=yaml.CLoader)
+            # print(json.dumps(self.loadedYaml, indent=4))
+        except Exception as e:
+            self.logger.log(LogLevel.ERROR, "Error while loading in yaml file. Please ensure the file is a valid yaml format and try again.\n\n" + str(e) + "\n")
+    
+    def validate_field_names(self):
+        '''
+        Ensures all fields are supported by the API
+        '''
+        # start by checking the top level
+        return self.validate_sublevel('top', self.loadedYaml, TOP_LEVEL)
+    
+    def validate_sublevel(self, level_name, to_validate, typed_keys):
+        '''
+        Takes in an object to validate and a dictionary mapping
+        allowed keys to their types. 
+        '''
+        is_valid = True
+        # some things (like scenes) are lists of a type. We need to check each entry in the list
+        # eventually we will probably want to check that if it's a list, we are expecting a list. for now, just leave this
+        if isinstance(to_validate, list):
+            for x in to_validate:
+                is_valid = is_valid and self.validate_sublevel(level_name, x, typed_keys)
+        else:
+            is_valid = True
+            found_keys = []
+            try:
+                for key in to_validate:
+                    if key in found_keys:
+                        self.logger.log(LogLevel.WARN, "'" + key + "' is duplicated at the " + level_name + " level of the yaml file")
+                        is_valid = False
+                    # check if the key is expected
+                    if key not in typed_keys:
+                        self.logger.log(LogLevel.WARN, "'" + key + "' is not a valid key at the " + level_name + " level of the yaml file. Allowed keys are " + str(typed_keys.keys()))
+                        is_valid = False
+                    else:
+                        # check type of object
+                        if isinstance(typed_keys[key], dict):
+                            if not self.validate_sublevel(key, to_validate[key], typed_keys[key]):
+                                is_valid = False
+                        # check basic type (string, int, etc)
+                        elif not (isinstance(to_validate[key], typed_keys[key]) or (type(typed_keys[key]) == type(float) and isinstance(to_validate[key], int))):
+                            self.logger.log(LogLevel.WARN, "'" + key + "' should be type " + str(typed_keys[key]) + " but is " + str(type(to_validate[key])) + " instead.")
+                            is_valid = False
+                    found_keys.append(key)
+            except:
+                self.logger.log(LogLevel.WARN, "'" + key + "' does not have a defined type at the " + level_name + " level of the yaml file")
+            for key in typed_keys:
+                if key not in found_keys:
+                    self.logger.log(LogLevel.WARN, "'" + key + "' is missing at the " + level_name + " level of the yaml file")
+                    is_valid = False
+        return is_valid
+
+    def __del__(self):
+        '''
+        Basic cleanup closing the file loaded in on close.
+        '''
+        self.logger.log(LogLevel.DEBUG, "Program closing...")
+        if (self.file):
+            self.file.close()
+
+    def validate_file_location(self, filename):
+        '''
+        Try to load in the yaml file. Checks that a path has been given, that the path leads to a yaml file,
+        and that the file is found. Returns the open binary file object.
+        '''
+        if not filename:
+            self.logger.log(LogLevel.ERROR, "No filename received. To run, please use 'python3 validator.py -f [filename]'")
+        if filename.strip()[-5:] != '.yaml':
+            self.logger.log(LogLevel.ERROR, "File must be a yaml file.")
+        try:
+            f = open(filename, 'r')
+            return f
+        except:
+            self.logger.log(LogLevel.ERROR, "Could not open file " + filename + ". Please make sure the path is valid and the file exists.")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='ITM - YAML Validator')
+
+    parser.add_argument('-f', '--filepath', dest='path', type=str, help='The path to the yaml file.')
+    args = parser.parse_args()
+
+    file = args.path
+    validator = YamlValidator(file)
+    # validate the field names in the valid
+    field_names_valid = validator.validate_field_names()
+    # print the answer for validity
+    if field_names_valid:
+        validator.logger.log(LogLevel.CRITICAL_INFO, file + " is valid!")
+    else:
+        validator.logger.log(LogLevel.CRITICAL_INFO, file + " is not valid.")


### PR DESCRIPTION
This is just the base of the validator. Right now all it does (after checking that the file exists and is a yaml, of course) is check for the expected keys and types (basic types, no enums yet and not focusing on min/max or list types or if it's required).

The next PR will include an updated api.py (possibly split into a folder for scenes and states, tbd) that includes additional parameters for each key (see the comment at the top of api.py). This should make adding and changing enums and other parts of properties simple and fast in the future.