### PR TITLE
Itm 228 - validator updates for new api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ validator
 
 # junk folder
 __pycache__
+
+output/*
+participant-data/*

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ In order for a yaml file to be considered "valid", the following conditions must
 
 #### Eval Mode
 When not running in training mode (-t), additional checks are implemented:
-* No supplies or treatments are allowed that are not in the simulator (no blankets or vented chest seals)
+* No supplies or treatments are allowed that are not in the simulator (no blankets)
 
 #### Injury/Location Matches
 Injuries are only allowed to have specific locations. Please follow the table to create valid matches.
@@ -175,7 +175,7 @@ Injuries are only allowed to have specific locations. Please follow the table to
 | `Ear Bleed` | `left face`, `right face` |
 | `Asthmatic` | `unspecified`, `internal` |
 | `Laceration` | `left forearm`, `right forearm`, `left stomach`, `right stomach`, `left thigh`, `right thigh`, `left calf`, `right calf`, `left wrist`, `right wrist` |
-| `Puncture` | `left neck`, `right neck`, `left bicep`, `right bicep`, `left shoulder`, `right shoulder`, `left stomach`, `right stomach`, `left side`, `right side`, `left thigh`, `right thigh` |
+| `Puncture` | `left neck`, `right neck`, `left bicep`, `right bicep`, `left shoulder`, `right shoulder`, `left stomach`, `right stomach`, `left side`, `right side`, `left thigh`, `right thigh`, `left chest`, `right chest`, `center chest` |
 | `Shrapnel` | `left face`, `right face`, `left calf`, `right calf` |
 | `Chest Collapse` | `left chest`, `right chest` |
 | `Amputation` | `left wrist`, `right wrist`, `left leg`, `right leg` |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ In order for a yaml file to be considered "valid", the following conditions must
         * `mental_status`
         * `breathing`
         * `heart_rate`
-        * `Spo2`
+        * `spo2`
     * `restricted_actions` cannot include `end_scene`
     * `session_complete` is a prohibited key in `scenario`
     * `scenario_complete` is a prohibited key in `state`
@@ -109,6 +109,7 @@ In order for a yaml file to be considered "valid", the following conditions must
 * If `scenes[n].action_mapping[m].action_type` is "APPLY_TREATMENT", `scenes[n].action_mapping[m].character_id` is required
 * If `scenes[n].action_mapping[m].action_type` is "CHECK_ALL_VITALS", `scenes[n].action_mapping[m].character_id` is required
 * If `scenes[n].action_mapping[m].action_type` is "CHECK_PULSE", `scenes[n].action_mapping[m].character_id` is required
+* If `scenes[n].action_mapping[m].action_type` is "CHECK_BLOOD_OXYGEN", `scenes[n].action_mapping[m].character_id` is required
 * If `scenes[n].action_mapping[m].action_type` is "CHECK_RESPIRATION", `scenes[n].action_mapping[m].character_id` is required
 * If `scenes[n].action_mapping[m].action_type` is "MOVE_TO_EVAC", `scenes[n].action_mapping[m].character_id` is required
 * If `scenes[n].action_mapping[m].action_type` is "MOVE_TO_EVAC", `scenes[n].action_mapping[m].parameters.evac_id` is required
@@ -118,7 +119,7 @@ In order for a yaml file to be considered "valid", the following conditions must
 #### Conditional Prohibitions
 * If `state.characters[n].demographics.military_branch` does not exist, `state.characters[n].demographics.rank` *and* `state.characters[n].demographics.rank_title` should _not_ be provided 
 
-#### Dependency Allowed Valuese
+#### Dependency Allowed Values
 * If `state.characters[n].vitals.conscious` is "False", `state.characters[n].vitals.avpu` should be "UNRESPONSIVE" and `state.characters[n].vitals.mental_status` should be "UNRESPONSIVE" 
 
 #### Value Matching
@@ -165,10 +166,10 @@ Injuries are only allowed to have specific locations. Please follow the table to
 | `Puncture` | `left neck`, `right neck`, `left bicep`, `right bicep`, `left shoulder`, `right shoulder`, `left stomach`, `right stomach`, `left side`, `right side`, `left thigh`, `right thigh` |
 | `Shrapnel` | `left face`, `right face`, `left calf`, `right calf` |
 | `Chest Collapse` | `left chest`, `right chest` |
-| `Amputation` | `left wrist`, `right wrist`, `left calf`, `right calf` |
-| `Burn` | `right forearm`, `left forearm`, `right calf`, `left calf`, `right thigh`, `left thigh`, `right stomach`, `left stomach`, `right bicep`, `left bicep`, `right shoulder`, `left shoulder`, `right side`, `left side`, `right chest`, `left chest`, `right wrist`, `left wrist`, `left face`, `right face`, `left neck`, `right neck`, `unspecified` |
-| `Abrasion` | `right forearm`, `left forearm`, `right calf`, `left calf`, `right thigh`, `left thigh`, `right stomach`, `left stomach`, `right bicep`, `left bicep`, `right shoulder`, `left shoulder`, `right side`, `left side`, `right chest`, `left chest`, `right wrist`, `left wrist`, `left face`, `right face`, `left neck`, `right neck`, `unspecified` |
-| `Broken Bone` | `right forearm`, `left forearm`, `right thigh`, `left thigh`, `right shoulder`, `left shoulder`, `right side`, `left side`, `right wrist`, `left wrist`, `left neck`, `right neck`, `unspecified` |
+| `Amputation` | `left wrist`, `right wrist`, `left leg`, `right leg` |
+| `Burn` | `right forearm`, `left forearm`, `right arm`, `left arm`, `right leg`, `left leg`, `right calf`, `left calf`, `right thigh`, `left thigh`, `right stomach`, `left stomach`, `right bicep`, `left bicep`, `right shoulder`, `left shoulder`, `right side`, `left side`, `right chest`, `left chest`, `right wrist`, `left wrist`, `left face`, `right face`, `left neck`, `right neck`, `unspecified` |
+| `Abrasion` | `right forearm`, `left forearm`, `right arm`, `left arm`, `right leg`, `left leg`, `right calf`, `left calf`, `right thigh`, `left thigh`, `right stomach`, `left stomach`, `right bicep`, `left bicep`, `right shoulder`, `left shoulder`, `right side`, `left side`, `right chest`, `left chest`, `right wrist`, `left wrist`, `left face`, `right face`, `left neck`, `right neck`, `unspecified` |
+| `Broken Bone` | `right forearm`, `left forearm`, `right arm`, `left arm`, `right leg`, `left leg`, `right thigh`, `left thigh`, `right shoulder`, `left shoulder`, `right side`, `left side`, `right wrist`, `left wrist`, `left neck`, `right neck`, `unspecified` |
 | `Internal` | `internal` | 
 
 #### Military Branches, Ranks, and Rank Titles

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ In order for a yaml file to be considered "valid", the following conditions must
 * If `scenes[n].action_mapping[m].action_type` is "TAG_CHARACTER", `scenes[n].action_mapping[m].parameters.category` is required
 
 #### Conditional Prohibitions
-* If `scenes[].index` is 0, `scenes[].state` should _not_ be provided
 * If `state.characters[n].demographics.military_branch` does not exist, `state.characters[n].demographics.rank` *and* `state.characters[n].demographics.rank_title` should _not_ be provided 
 
 #### Dependency Allowed Valuese

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ In order for a yaml file to be considered "valid", the following conditions must
 
 #### Eval Mode
 When not running in training mode (-t), additional checks are implemented:
-* No supplies or treatments are allowed that are not in the simulator (no blankets, epi pens, or vented chest seals)
+* No supplies or treatments are allowed that are not in the simulator (no blankets or vented chest seals)
 
 #### Injury/Location Matches
 Injuries are only allowed to have specific locations. Please follow the table to create valid matches.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ In order for a yaml file to be considered "valid", the following conditions must
     * `session_complete` is a prohibited key in `scenario`
     * `scenario_complete` is a prohibited key in `state`
     * `elapsed_time` is a prohibited key in `state`
+    * `action_type` in `action_mapping` cannot be one of `restricted_actions`
     * In `scenes.state`:
-        * Only `characters` is required
+        * Only `characters` is required (if `persist_characters` is false)
         * Only one `unstructured` property is required in the whole object
         * `Mission`, `Environment`, `DecisionEnvironment`, and `SimEnvironment` only require the `unstructured` property
         * `type` is a prohibted key in `SimEnvironment`
@@ -107,25 +108,21 @@ In order for a yaml file to be considered "valid", the following conditions must
 * If `state.characters[n].demographics.military_disposition` is "Allied US", `state.characters[n].demographics.military_branch` is required 
 * If `state.characters[n].injuries[m].name` is "Burn", `state.characters[n].injuries[m].severity` is required 
 * If `scenes[n].action_mapping[m].action_type` is "APPLY_TREATMENT", `scenes[n].action_mapping[m].character_id` is required
-* If `scenes[n].action_mapping[m].action_type` is "CHECK_ALL_VITALS", `scenes[n].action_mapping[m].character_id` is required
-* If `scenes[n].action_mapping[m].action_type` is "CHECK_PULSE", `scenes[n].action_mapping[m].character_id` is required
-* If `scenes[n].action_mapping[m].action_type` is "CHECK_BLOOD_OXYGEN", `scenes[n].action_mapping[m].character_id` is required
-* If `scenes[n].action_mapping[m].action_type` is "CHECK_RESPIRATION", `scenes[n].action_mapping[m].character_id` is required
 * If `scenes[n].action_mapping[m].action_type` is "MOVE_TO_EVAC", `scenes[n].action_mapping[m].character_id` is required
 * If `scenes[n].action_mapping[m].action_type` is "MOVE_TO_EVAC", `scenes[n].action_mapping[m].parameters.evac_id` is required
 * If `scenes[n].action_mapping[m].action_type` is "TAG_CHARACTER", `scenes[n].action_mapping[m].character_id` is required
-* If `scenes[n].action_mapping[m].action_type` is "TAG_CHARACTER", `scenes[n].action_mapping[m].parameters.category` is required
 
 #### Conditional Prohibitions
 * If `state.characters[n].demographics.military_branch` does not exist, `state.characters[n].demographics.rank` *and* `state.characters[n].demographics.rank_title` should _not_ be provided 
 
 #### Dependency Allowed Values
-* If `state.characters[n].vitals.conscious` is "False", `state.characters[n].vitals.avpu` should be "UNRESPONSIVE" and `state.characters[n].vitals.mental_status` should be "UNRESPONSIVE" 
+* If `state.characters[n].vitals.conscious` is "False", `state.characters[n].vitals.avpu` should be "UNRESPONSIVE" or "PAIN" and `state.characters[n].vitals.mental_status` should be "UNRESPONSIVE" 
 
 #### Value Matching
 * `state.characters[n].injuries[m].source_character` must be one of the `state.characters.character_id`'s
 * `scenes[n].tagging.reference` must be one of the `scenes[n].index`'s 
 * `scenes[n].action_mapping[m].next_scene` must be one of the `scenes[n].index`'s
+* `scenes[n].action_mapping[m].parameters.evac_id` must be one of the `scenes[n].state.environment.decision_environment.aid_delay[p].id`'s
 
 #### Character Matching
 * `scenes[0].action_mapping[].character_id`: `state.characters[].id`,
@@ -146,7 +143,6 @@ In order for a yaml file to be considered "valid", the following conditions must
 * `state.environment.decision_environment.aid_delay[].id` must not have any repeated values
 
 #### Other Rules
-* At least one scene must have `end_scene_allowed=true`
 * `scenes[n].action_mapping[m].parameters.treatment` must come from `SupplyTypeEnum` 
 * `scenes[n].action_mapping[m].parameters.location` must come from `InjuryLocationEnum` 
 * `scenes[n].action_mapping[m].parameters.category` must come from `CharacterTagEnum` 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ In order for a yaml file to be considered "valid", the following conditions must
 * `scenes[].state.characters[].id` must not have any repeated values within each `scene`
 * `scenes[].action_mapping[].action_id` must not have any repeated values within each `scene`
 * `state.characters[].id` must not have any repeated values
+* `scenes[].index` must not have any repeated values
 * `state.environment.decision_environment.aid_delay[].id` must not have any repeated values
 
 #### Other Rules

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ In order for a yaml file to be considered "valid", the following conditions must
 * If `scenes[n].action_mapping[m].action_type` is "TAG_CHARACTER", `scenes[n].action_mapping[m].character_id` is required
 
 #### Conditional Prohibitions
+* If `scenes[].index` is 0, `scenes[].state` should _not_ be provided
 * If `state.characters[n].demographics.military_branch` does not exist, `state.characters[n].demographics.rank` *and* `state.characters[n].demographics.rank_title` should _not_ be provided 
 
 #### Dependency Allowed Values

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ensure that the path leads to a yaml file.
 
 See full usage options below:
 ```
-usage: validator.py [-h] [-u [-f PATH] | -f PATH ]
+usage: validator.py [-h] [-u [-f PATH] [-e] [-t] | -f PATH [-e] [-t]]
 ```
 
 ## API Changes
@@ -151,6 +151,10 @@ In order for a yaml file to be considered "valid", the following conditions must
 * `scenario.state.characters.demographics.mission_importance` must be consistent with `scenario.state.mission.character_importance `
     * Every character with `mission_importance` should be an entry in `character_importance`, and vice-versa 
     * This does not include "normal", which is the default level of importance. For example, a character may not specify `mission_importance` and `character_importance` may explicitly specify the character with importance "normal", or a character may specify `mission_importance` with "normal" and `character_importance` may not list that character 
+
+#### Eval Mode
+When running in eval mode (-e), additional checks are implemented:
+* No supplies or treatments are allowed that are not in the simulator (no blankets, epi pens, or vented chest seals)
 
 #### Injury/Location Matches
 Injuries are only allowed to have specific locations. Please follow the table to create valid matches.

--- a/README.md
+++ b/README.md
@@ -108,9 +108,14 @@ In order for a yaml file to be considered "valid", the following conditions must
 * If `state.characters[n].demographics.military_disposition` is "Allied US", `state.characters[n].demographics.military_branch` is required 
 * If `state.characters[n].injuries[m].name` is "Burn", `state.characters[n].injuries[m].severity` is required 
 * If `scenes[n].action_mapping[m].action_type` is "APPLY_TREATMENT", `scenes[n].action_mapping[m].character_id` is required
+* If `scenes[n].action_mapping[m].action_type` is "CHECK_ALL_VITALS", `scenes[n].action_mapping[m].character_id` is required
+* If `scenes[n].action_mapping[m].action_type` is "CHECK_PULSE", `scenes[n].action_mapping[m].character_id` is required
+* If `scenes[n].action_mapping[m].action_type` is "CHECK_RESPIRATION", `scenes[n].action_mapping[m].character_id` is required
+* If `scenes[n].action_mapping[m].action_type` is "CHECK_BLOOD_OXYGEN", `scenes[n].action_mapping[m].character_id` is required
 * If `scenes[n].action_mapping[m].action_type` is "MOVE_TO_EVAC", `scenes[n].action_mapping[m].character_id` is required
 * If `scenes[n].action_mapping[m].action_type` is "MOVE_TO_EVAC", `scenes[n].action_mapping[m].parameters.evac_id` is required
 * If `scenes[n].action_mapping[m].action_type` is "TAG_CHARACTER", `scenes[n].action_mapping[m].character_id` is required
+* If `scenes[n].action_mapping[m].action_type` is "TAG_CHARACTER", `scenes[n].action_mapping[m].parameters.category` is required
 
 #### Conditional Prohibitions
 * If `scenes[].index` is 0, `scenes[].state` should _not_ be provided

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ In order for a yaml file to be considered "valid", the following conditions must
 * `state.environment.decision_environment.aid_delay[].id` must not have any repeated values
 
 #### Other Rules
+* At least one scene must have `final_scene=true`
 * `scenes[n].action_mapping[m].parameters.treatment` must come from `SupplyTypeEnum` 
 * `scenes[n].action_mapping[m].parameters.location` must come from `InjuryLocationEnum` 
 * `scenes[n].action_mapping[m].parameters.category` must come from `CharacterTagEnum` 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ensure that the path leads to a yaml file.
 
 See full usage options below:
 ```
-usage: validator.py [-h] [-u [-f PATH] [-e] [-t] | -f PATH [-e] [-t]]
+usage: validator.py [-h] [-u [-f PATH] [-t] | -f PATH [-t]]
 ```
 
 ## API Changes
@@ -153,7 +153,7 @@ In order for a yaml file to be considered "valid", the following conditions must
     * This does not include "normal", which is the default level of importance. For example, a character may not specify `mission_importance` and `character_importance` may explicitly specify the character with importance "normal", or a character may specify `mission_importance` with "normal" and `character_importance` may not list that character 
 
 #### Eval Mode
-When running in eval mode (-e), additional checks are implemented:
+When not running in training mode (-t), additional checks are implemented:
 * No supplies or treatments are allowed that are not in the simulator (no blankets, epi pens, or vented chest seals)
 
 #### Injury/Location Matches

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ In order for a yaml file to be considered "valid", the following conditions must
 * `scenes[].index` must not have any repeated values
 * `state.environment.decision_environment.aid_delay[].id` must not have any repeated values
 
+#### Training Only Supplies
+Any supply name placed in this array will be excluded from the allowed supplies if eval mode is true.
+
 #### Other Rules
 * At least one scene must have `final_scene=true`
 * `scenes[n].action_mapping[m].parameters.treatment` must come from `SupplyTypeEnum` 
@@ -166,7 +169,7 @@ In order for a yaml file to be considered "valid", the following conditions must
 
 #### Eval Mode
 When not running in training mode (-t), additional checks are implemented:
-* No supplies or treatments are allowed that are not in the simulator (no blankets)
+* No supplies or treatments are allowed that are not in the simulator. Put the names of these treatments in the trainingOnlySupplies array in dependencies.json
 
 #### Injury/Location Matches
 Injuries are only allowed to have specific locations. Please follow the table to create valid matches.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ Ensure that the path leads to a yaml file.
 
 See full usage options below:
 ```
-usage: validator.py [-h] [-u [-f PATH] [-t] | -f PATH [-t]]
-```
+usage: validator.py [-h] [-f PATH] [-u] [-t]
+options:
+  -h, --help                Show this help message and exit.
+  -f PATH, --filepath PATH  The path to the yaml file. Required if -u is not specified.
+  -u, --update              Switch to update the api files or not. Required if -f is not specified.
+  -t, --train               Validate a training scenario yaml.```
 
 ## API Changes
 - When the Swagger API changes, make sure you upload the newest version as `api.yaml` to the `api_files` directory.

--- a/README.md
+++ b/README.md
@@ -90,9 +90,7 @@ In order for a yaml file to be considered "valid", the following conditions must
         * `breathing`
         * `heart_rate`
         * `Spo2`
-    * `injury.status` may only be `hidden`, `discoverable`, or `visible`
     * `restricted_actions` cannot include `end_scene`
-    * `visited` is a prohibited key in `character`
     * `session_complete` is a prohibited key in `scenario`
     * `scenario_complete` is a prohibited key in `state`
     * `elapsed_time` is a prohibited key in `state`

--- a/api_files/api.yaml
+++ b/api_files/api.yaml
@@ -100,7 +100,7 @@ paths:
             type: string
         - name: scenario_id
           in: query
-          description: "a scenario id to start, used internally by TA3"
+          description: "the scenario id to run; incompatible with /ta2/startSession's max_scenarios parameter"
           required: false
           style: form
           explode: true
@@ -116,9 +116,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Scenario"
         "400":
-          description: Invalid Session ID or there is already an active scenario
-        "403":
-          description: Specifying a scenario ID is unauthorized
+          description: Invalid Session ID, there is already an active scenario, or scenario_id was specified with max_scenarios
         "404":
           description: Scenario ID not found
         "500":
@@ -128,6 +126,8 @@ paths:
               schema:
                 type: string
                 x-content-type: text/plain
+        "503":
+          description: Could not communicate with TA1 server
       x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller
   /ta2/getAlignmentTarget:
     get:
@@ -198,7 +198,7 @@ paths:
             type: string
       responses:
         "200":
-          description: Successful Response
+          description: Successful Response; if server is configured to run without TA1, then session alignment will be empty/None/null.
           content:
             application/json:
               schema:
@@ -214,6 +214,8 @@ paths:
               schema:
                 type: string
                 x-content-type: text/plain
+        "503":
+          description: Could not get session alignment from TA1
       x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller
   /ta2/{scenario_id}/getState:
     get:
@@ -811,7 +813,7 @@ components:
           $ref: "#/components/schemas/BreathingLevelEnum"
         heart_rate:
           $ref: "#/components/schemas/HeartRateEnum"
-        Spo2:
+        spo2:
           type: number
           format: float
           description: blood oxygen level (percentage)

--- a/api_files/api.yaml
+++ b/api_files/api.yaml
@@ -705,6 +705,7 @@ components:
         - name
         - unstructured
         - demographics
+        - vitals
       type: object
       description: a character in the scene, including injured patients, civilians, medics, etc.
       properties:
@@ -843,6 +844,7 @@ components:
         - index
         - end_scene_allowed
         - action_mapping
+        - state
       type: object
       description: the specification for a scene in the scenario
       properties:

--- a/api_files/api.yaml
+++ b/api_files/api.yaml
@@ -844,7 +844,6 @@ components:
         - index
         - end_scene_allowed
         - action_mapping
-        - state
       type: object
       description: the specification for a scene in the scenario
       properties:
@@ -854,12 +853,12 @@ components:
           minimum: 0
         state:
           $ref: "#/components/schemas/State"
-        end_scene_allowed:
-          type: boolean
-          description: Whether ADMs can explicitly end the scene
         final_scene:
           type: boolean
           description: Whether this is the final scene in the scenario
+        end_scene_allowed:
+          type: boolean
+          description: Whether ADMs can explicitly end the scene
         persist_characters:
           type: boolean
           description: Whether characters should persist from the previous scene

--- a/api_files/api.yaml
+++ b/api_files/api.yaml
@@ -1621,6 +1621,7 @@ components:
         - left side
         - right chest
         - left chest
+        - center chest
         - right wrist
         - left wrist
         - left face

--- a/api_files/api.yaml
+++ b/api_files/api.yaml
@@ -855,6 +855,12 @@ components:
         end_scene_allowed:
           type: boolean
           description: Whether ADMs can explicitly end the scene
+        final_scene:
+          type: boolean
+          description: Whether this is the final scene in the scenario
+        persist_characters:
+          type: boolean
+          description: Whether characters should persist from the previous scene
         probe_config:
           description: TA1-provided probe configuration, ignored by TA3
           type: array
@@ -1596,6 +1602,10 @@ components:
       enum:
         - right forearm
         - left forearm
+        - right hand
+        - left hand
+        - right leg
+        - left leg
         - right calf
         - left calf
         - right thigh
@@ -1685,6 +1695,7 @@ components:
       enum:
         - APPLY_TREATMENT
         - CHECK_ALL_VITALS
+        - CHECK_BLOOD_OXYGEN
         - CHECK_PULSE
         - CHECK_RESPIRATION
         - DIRECT_MOBILE_CHARACTERS

--- a/api_files/dependencies.json
+++ b/api_files/dependencies.json
@@ -52,30 +52,6 @@
             },
             {
                 "conditions": {
-                    "value": "CHECK_ALL_VITALS"
-                },
-                "required": [
-                    "scenes[].action_mapping[].character_id"
-                ]
-            },
-            {
-                "conditions": {
-                    "value": "CHECK_PULSE"
-                },
-                "required": [
-                    "scenes[].action_mapping[].character_id"
-                ]
-            },
-            {
-                "conditions": {
-                    "value": "CHECK_RESPIRATION"
-                },
-                "required": [
-                    "scenes[].action_mapping[].character_id"
-                ]
-            },
-            {
-                "conditions": {
                     "value": "MOVE_TO_EVAC"
                 },
                 "required": [
@@ -88,8 +64,7 @@
                     "value": "TAG_CHARACTER"
                 },
                 "required": [
-                    "scenes[].action_mapping[].character_id",
-                    "scenes[].action_mapping[].parameters.category"
+                    "scenes[].action_mapping[].character_id"
                 ]
             }
         ]
@@ -153,7 +128,8 @@
         "state.characters[].vitals.conscious": {
             "False": {
                 "state.characters[].vitals.avpu": [
-                    "UNRESPONSIVE"
+                    "UNRESPONSIVE",
+                    "PAIN"
                 ],
                 "state.characters[].vitals.mental_status": [
                     "UNRESPONSIVE"
@@ -183,8 +159,8 @@
                     "right thigh",
                     "left calf",
                     "right calf",
-                    "left wrist",
-                    "right wrist"
+                    "left hand",
+                    "right hand"
                 ]
             },
             "Puncture": {
@@ -293,6 +269,8 @@
                     "left wrist",
                     "left neck",
                     "right neck",
+                    "left leg",
+                    "right leg",
                     "unspecified"
                 ]
             },
@@ -1809,7 +1787,8 @@
     "valueMatch": {
         "state.characters[].injuries[].source_character": "state.characters[].id",
         "scenes[].action_mapping[].next_scene": "scenes[].index",
-        "scenes[].tagging.reference": "scenes[].index"
+        "scenes[].tagging.reference": "scenes[].index",
+        "scenes[].action_mapping[].parameters.evac_id": "scenes[].state.environment.decision_environment.aid_delay[].id"
     },
     "characterMatching": [
         "scenes[].state.characters[].injuries[].source_character",
@@ -1820,7 +1799,7 @@
     ],
     "unique": {
         "state.environment.decision_environment.aid_delay[].id": "state",
-        "scenes[].state.environment.decision_environment.aid_delay[].id" : "scenes[]",
+        "scenes[].state.environment.decision_environment.aid_delay[].id": "scenes[]",
         "scenes[].state.characters[].id": "scenes[]",
         "scenes[].action_mapping[].action_id": "scenes[]",
         "state.characters[].id": "state"

--- a/api_files/dependencies.json
+++ b/api_files/dependencies.json
@@ -1850,5 +1850,6 @@
         "scenes[].action_mapping[].action_id": "scenes[]",
         "scenes[].index": "scenes",
         "state.characters[].id": "state"
-    }
+    },
+    "trainingOnlySupplies": []
 }

--- a/api_files/dependencies.json
+++ b/api_files/dependencies.json
@@ -219,7 +219,10 @@
                     "left side",
                     "right side",
                     "left thigh",
-                    "right thigh"
+                    "right thigh",
+                    "left chest",
+                    "right chest",
+                    "center chest"
                 ]
             },
             "Shrapnel": {

--- a/api_files/dependencies.json
+++ b/api_files/dependencies.json
@@ -95,16 +95,6 @@
         ]
     },
     "conditionalForbid": {
-        "scenes[].index": [
-            {
-                "conditions": {
-                    "value": 0
-                },
-                "forbid": [
-                    "scenes[].state"
-                ]
-            }
-        ],
         "state.characters[].demographics.military_disposition": [
             {
                 "conditions": {

--- a/api_files/dependencies.json
+++ b/api_files/dependencies.json
@@ -70,6 +70,16 @@
         ]
     },
     "conditionalForbid": {
+        "scenes[].index": [
+            {
+                "conditions": {
+                    "value": 0
+                },
+                "forbid": [
+                    "scenes[].state"
+                ]
+            }
+        ],
         "state.characters[].demographics.military_disposition": [
             {
                 "conditions": {

--- a/api_files/dependencies.json
+++ b/api_files/dependencies.json
@@ -1812,6 +1812,7 @@
         "scenes[].state.environment.decision_environment.aid_delay[].id": "scenes[]",
         "scenes[].state.characters[].id": "scenes[]",
         "scenes[].action_mapping[].action_id": "scenes[]",
+        "scenes[].index": "scenes",
         "state.characters[].id": "state"
     }
 }

--- a/api_files/dependencies.json
+++ b/api_files/dependencies.json
@@ -52,6 +52,38 @@
             },
             {
                 "conditions": {
+                    "value": "CHECK_ALL_VITALS"
+                },
+                "required": [
+                    "scenes[].action_mapping[].character_id"
+                ]
+            },
+            {
+                "conditions": {
+                    "value": "CHECK_PULSE"
+                },
+                "required": [
+                    "scenes[].action_mapping[].character_id"
+                ]
+            },
+            {
+                "conditions": {
+                    "value": "CHECK_RESPIRATION"
+                },
+                "required": [
+                    "scenes[].action_mapping[].character_id"
+                ]
+            },
+            {
+                "conditions": {
+                    "value": "CHECK_BLOOD_OXYGEN"
+                },
+                "required": [
+                    "scenes[].action_mapping[].character_id"
+                ]
+            },
+            {
+                "conditions": {
                     "value": "MOVE_TO_EVAC"
                 },
                 "required": [
@@ -64,7 +96,8 @@
                     "value": "TAG_CHARACTER"
                 },
                 "required": [
-                    "scenes[].action_mapping[].character_id"
+                    "scenes[].action_mapping[].character_id",
+                    "scenes[].action_mapping[].parameters.category"
                 ]
             }
         ]

--- a/api_files/generator.py
+++ b/api_files/generator.py
@@ -64,23 +64,12 @@ class ApiGenerator:
         required_vitals.append('Spo2')
         new_api['components']['schemas']['Vitals']['required'] = required_vitals
 
-        # injury status enum should only include hidden, discoverable, or visible
-        new_api['components']['schemas']['InjuryStatusEnum']['enum'] = ['hidden', 'discoverable', 'visible']
-
         # create a new enum for restricted_actions that doesn't include END_SCENE
         new_api['components']['schemas']['RestrictedActionsEnum'] = copy.deepcopy(new_api['components']['schemas']['ActionTypeEnum'])
         new_api['components']['schemas']['RestrictedActionsEnum']['enum'].remove('END_SCENE')
 
         # set restricted_actions to this enum
         new_api['components']['schemas']['Scene']['properties']['restricted_actions']['items']['$ref'] = "#/components/schemas/RestrictedActionsEnum"
-
-        # validator does not allow visited in character
-        try:
-            if 'visited' in new_api['components']['schemas']['Character']['required']:
-                new_api['components']['schemas']['Character']['required'].remove('visited')
-            del new_api['components']['schemas']['Character']['properties']['visited']
-        except: 
-            self.logger.log(LogLevel.INFO, "No 'visited' property found in 'Character'. Not removing anything")
 
         # validator does not allow session complete in scenario
         try:

--- a/api_files/state_changes.yaml
+++ b/api_files/state_changes.yaml
@@ -103,6 +103,11 @@ components:
           example: 22 YO male Marine hit by an IED. Puncture wound on the left side
             of the neck.  Burns cover about 30 of his body.
           type: string
+        visited:
+          default: false
+          description: whether or not this character has been visited by the ADM in
+            the current scenario
+          type: boolean
         vitals:
           $ref: '#/components/schemas/Vitals'
       required:
@@ -338,6 +343,8 @@ components:
       - hidden
       - discoverable
       - visible
+      - discovered
+      - treated
       type: string
     InjuryTriggerEnum:
       description: What source caused character injuries
@@ -904,12 +911,6 @@ components:
     Vitals:
       description: Vital levels and other indications of health
       properties:
-        Spo2:
-          description: blood oxygen level (percentage)
-          format: float
-          maximum: 100.0
-          minimum: 0.0
-          type: number
         ambulatory:
           description: whether or not the character can walk
           type: boolean
@@ -924,6 +925,12 @@ components:
           $ref: '#/components/schemas/HeartRateEnum'
         mental_status:
           $ref: '#/components/schemas/MentalStatusEnum'
+        spo2:
+          description: blood oxygen level (percentage)
+          format: float
+          maximum: 100.0
+          minimum: 0.0
+          type: number
       required:
       - conscious
       - avpu

--- a/api_files/state_changes.yaml
+++ b/api_files/state_changes.yaml
@@ -304,6 +304,10 @@ components:
       enum:
       - right forearm
       - left forearm
+      - right hand
+      - left hand
+      - right leg
+      - left leg
       - right calf
       - left calf
       - right thigh

--- a/api_files/state_changes.yaml
+++ b/api_files/state_changes.yaml
@@ -115,6 +115,7 @@ components:
       - name
       - unstructured
       - demographics
+      - vitals
       type: object
     CharacterRoleEnum:
       description: The primary role a character has in the mission, in terms of the

--- a/api_files/validator_api.yaml
+++ b/api_files/validator_api.yaml
@@ -308,6 +308,11 @@ components:
           example: 22 YO male Marine hit by an IED. Puncture wound on the left side
             of the neck.  Burns cover about 30 of his body.
           type: string
+        visited:
+          default: false
+          description: whether or not this character has been visited by the ADM in
+            the current scenario
+          type: boolean
         vitals:
           $ref: '#/components/schemas/Vitals'
       required:
@@ -610,6 +615,8 @@ components:
       - hidden
       - discoverable
       - visible
+      - discovered
+      - treated
       type: string
     InjuryTriggerEnum:
       description: What source caused character injuries
@@ -1355,12 +1362,6 @@ components:
     Vitals:
       description: Vital levels and other indications of health
       properties:
-        Spo2:
-          description: blood oxygen level (percentage)
-          format: float
-          maximum: 100.0
-          minimum: 0.0
-          type: number
         ambulatory:
           description: whether or not the character can walk
           type: boolean
@@ -1375,6 +1376,12 @@ components:
           $ref: '#/components/schemas/HeartRateEnum'
         mental_status:
           $ref: '#/components/schemas/MentalStatusEnum'
+        spo2:
+          description: blood oxygen level (percentage)
+          format: float
+          maximum: 100.0
+          minimum: 0.0
+          type: number
       required:
       - conscious
       - avpu
@@ -1477,7 +1484,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AlignmentResults'
-          description: Successful Response
+          description: Successful Response; if server is configured to run without
+            TA1, then session alignment will be empty/None/null.
         '400':
           description: Session ID not found
         '403':
@@ -1489,6 +1497,8 @@ paths:
                 type: string
                 x-content-type: text/plain
           description: An exception occurred on the server; see returned error string.
+        '503':
+          description: Could not get session alignment from TA1
       summary: Retrieve session alignment from TA1
       tags:
       - itm-ta2-eval
@@ -1507,7 +1517,8 @@ paths:
         schema:
           type: string
         style: form
-      - description: a scenario id to start, used internally by TA3
+      - description: the scenario id to run; incompatible with /ta2/startSession's
+          max_scenarios parameter
         explode: true
         in: query
         name: scenario_id
@@ -1524,9 +1535,8 @@ paths:
           description: Successful operation; scenario data returned, or session_complete
             is True
         '400':
-          description: Invalid Session ID or there is already an active scenario
-        '403':
-          description: Specifying a scenario ID is unauthorized
+          description: Invalid Session ID, there is already an active scenario, or
+            scenario_id was specified with max_scenarios
         '404':
           description: Scenario ID not found
         '500':
@@ -1536,6 +1546,8 @@ paths:
                 type: string
                 x-content-type: text/plain
           description: An exception occurred on the server; see returned error string.
+        '503':
+          description: Could not communicate with TA1 server
       summary: Get the next scenario
       tags:
       - itm-ta2-eval

--- a/api_files/validator_api.yaml
+++ b/api_files/validator_api.yaml
@@ -320,6 +320,7 @@ components:
       - name
       - unstructured
       - demographics
+      - vitals
       type: object
     CharacterRoleEnum:
       description: The primary role a character has in the mission, in terms of the
@@ -1079,6 +1080,7 @@ components:
       - index
       - end_scene_allowed
       - action_mapping
+      - state
       type: object
     SemanticTypeEnum:
       default: and

--- a/api_files/validator_api.yaml
+++ b/api_files/validator_api.yaml
@@ -121,6 +121,7 @@ components:
       enum:
       - APPLY_TREATMENT
       - CHECK_ALL_VITALS
+      - CHECK_BLOOD_OXYGEN
       - CHECK_PULSE
       - CHECK_RESPIRATION
       - DIRECT_MOBILE_CHARACTERS
@@ -576,6 +577,10 @@ components:
       enum:
       - right forearm
       - left forearm
+      - right hand
+      - left hand
+      - right leg
+      - left leg
       - right calf
       - left calf
       - right thigh
@@ -1009,6 +1014,7 @@ components:
       enum:
       - APPLY_TREATMENT
       - CHECK_ALL_VITALS
+      - CHECK_BLOOD_OXYGEN
       - CHECK_PULSE
       - CHECK_RESPIRATION
       - DIRECT_MOBILE_CHARACTERS
@@ -1052,10 +1058,16 @@ components:
         end_scene_allowed:
           description: Whether ADMs can explicitly end the scene
           type: boolean
+        final_scene:
+          description: Whether this is the final scene in the scenario
+          type: boolean
         index:
           description: The order the scene appears in the scenario
           minimum: 0
           type: integer
+        persist_characters:
+          description: Whether characters should persist from the previous scene
+          type: boolean
         probe_config:
           description: TA1-provided probe configuration, ignored by TA3
           items:

--- a/api_files/validator_api.yaml
+++ b/api_files/validator_api.yaml
@@ -1092,7 +1092,6 @@ components:
       - index
       - end_scene_allowed
       - action_mapping
-      - state
       type: object
     SemanticTypeEnum:
       default: and

--- a/test.yaml
+++ b/test.yaml
@@ -310,6 +310,7 @@ scenes:
   - index: 1
     end_scene_allowed: false
     final_scene: true
+    persist_characters: true
     # NOTE: The tagging property is NOT planned to be supported in the Metrics Evaluation.  Tagging can be achieved with explicit action_mappings.
     tagging:
       reference: 0 # Re-use the tagging configuration from the specified scene index
@@ -318,73 +319,6 @@ scenes:
         unstructured: No mission parameters # mission is not required, but if it is provided, unstructured is required
         character_importance: # A list of pairs of character ids with an indicator of how mission-critical the character is
           - Captain_01: important # controlled vocab includes low, normal, important, priority, vip; must be kept consistent with demographics.mission_importance
-      characters:
-        - id: Marine_burns_01
-          name: Bob
-          unstructured: >
-            A 25 year-old male Marine hit by an IED. 
-            No obvious external injuries.
-          unstructured_postassess:
-            > # Unstructured text can change after assessment to reflect discovered injuries
-            A 25 year-old male Marine hit by an IED. 
-            No obvious external injuries, but burns over 50% of body.
-          rapport: neutral # A measure of closeness or affinity towards the player/medic. Controlled vocab: loathing, dislike, neutral, close, familial
-          demographics:
-            age: 25
-            sex: M
-            race: White # controlled vocab includes American Indian, White, Hispanic, Black, Asian, Pacific Islander
-            military_disposition: Allied US # controlled vocab includes Allied US, Allied, Civilian, Military Adversary, Non-Military Adversary
-            military_branch: US Marine Corps # controlled vocab includes US Army, US Navy, US Air Force, US Marine Corps, US Space Force, US Coast Guard
-            rank: E-2 # For controlled vocab, see "Paygrade" column of https://www.military.com/join-military/military-ranks-everything-you-need-know.html
-            rank_title: Private First Class # For controlled vocab, see "Rank" column of https://www.military.com/join-military/military-ranks-everything-you-need-know.html
-            skills: # Describes abilities a character can have; if not listed, assume no skill in the area
-              - skill_type: Combat # controlled vocab includes Medical, Combat, Specialist, Communications, Command
-                level: qualified # controlled vocab includes novice, qualified, competent, skilled, expert
-            role: Infantry # The role a character has in the mission; controlled vocab includes Infantry, SEAL, Command, Intelligence, Medical, Specialist, Communications, etc.
-          vitals:
-            conscious: true
-            avpu: ALERT # level of response; controlled vocab includes ALERT, VOICE, PAIN, UNRESPONSIVE; see https://www.firstresponse.org.uk/first-aid-az/3-general/first-aid/79-levels-of-response
-            ambulatory: true
-            mental_status: AGONY # controlled vocab includes AGONY, CALM, CONFUSED, SHOCK, UPSET, UNRESPONSIVE
-            breathing: FAST # controlled vocab includes NORMAL, FAST, RESTRICTED, NONE
-            heart_rate: FAST # controlled vocab includes NONE, FAINT, NORMAL, FAST
-            spo2: 97 # a percentage
-          injuries:
-            - name: Burn # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone
-              location: unspecified # controlled vocab includes forearm, calf, hand, leg, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, unspecified.  Most locations allow a left and right designation.
-              severity: substantial # controlled vocab: minor, moderate, substantial, major, extreme
-              status: discoverable # controlled vocab: hidden, discoverable, discovered, treated, visible
-        - id: Captain_01
-          name: Katie
-          unstructured: >
-            An uninjuried 30-40 YO female who escaped harm.
-            No obvious external injuries.
-          rapport: close # A measure of closeness or affinity towards the player/medic. Controlled vocab: loathing, dislike, neutral, close, familial
-          demographics:
-            age: 35
-            sex: F
-            race: White # controlled vocab includes American Indian, White, Hispanic, Black, Asian, Pacific Islander
-            military_disposition: Allied US # controlled vocab includes Allied US, Allied, Civilian, Military Adversary, Non-Military Adversary
-            military_branch: US Marine Corps # controlled vocab includes US Army, US Navy, US Air Force, US Marine Corps, US Space Force, US Coast Guard
-            rank: O-3 # For controlled vocab, see "Paygrade" column of https://www.military.com/join-military/military-ranks-everything-you-need-know.html
-            rank_title: Captain # For controlled vocab, see "Rank" column of https://www.military.com/join-military/military-ranks-everything-you-need-know.html
-            skills: # Describes abilities a character can have; if not listed, assume no skill in the area
-              - skill_type: Combat # controlled vocab includes Medical, Combat, Specialist, Communications, Command
-                level: skilled # controlled vocab includes novice, qualified, competent, skilled, expert
-              - skill_type: Command
-                level: competent
-              - skill_type: Communications
-                level: qualified
-            role: Command # The role a character has in the mission; controlled vocab includes Infantry, SEAL, Command, Intelligence, Medical, Specialist, Communications, etc.
-            mission_importance: important # controlled vocab includes low, normal, important, priority, vip; must be kept consistent with mission.character_importance
-          vitals:
-            conscious: true
-            avpu: ALERT # controlled vocab includes ALERT, VOICE, PAIN, UNRESPONSIVE; see https://www.firstresponse.org.uk/first-aid-az/3-general/first-aid/79-levels-of-response
-            ambulatory: true
-            mental_status: CALM # controlled vocab includes AGONY, CALM, CONFUSED, SHOCK, UPSET, UNRESPONSIVE
-            breathing: NORMAL # controlled vocab includes NORMAL, FAST, RESTRICTED, NONE
-            heart_rate: NORMAL # controlled vocab includes NONE, FAINT, NORMAL, FAST
-            spo2: 99 # a percentage
       environment:
         decision_environment:
           unstructured: >

--- a/test.yaml
+++ b/test.yaml
@@ -64,9 +64,9 @@ state:
     - { type: Decompression Needle, quantity: 4 }
     - { type: Nasopharyngeal airway, quantity: 2 }
     - { type: Pulse Oximeter, quantity: 1, reusable: True }
-    - { type: Blanket, quantity: 2 } # Available for training scenarios only
-    - { type: Epi Pen, quantity: 1, reusable: True } # Available for training scenarios only
-    - { type: Vented Chest Seal, quantity: 2 } # Available for training scenarios only
+    - { type: Blanket, quantity: 0 } # Available for training scenarios only
+    - { type: Epi Pen, quantity: 0, reusable: True } # Available for training scenarios only
+    - { type: Vented Chest Seal, quantity: 0 } # Available for training scenarios only
     - { type: Pain Medications, quantity: 2 }
     - { type: Splint, quantity: 2 }
     - { type: Blood, quantity: 5 }  # quantity is in units; no notion of blood type

--- a/test.yaml
+++ b/test.yaml
@@ -158,6 +158,9 @@ scenes:
   - index: 0
     # The scene with index = 0 uses the state defined at the scenario level
     end_scene_allowed: false
+    state:
+      unstructured: first scene
+      characters: []
     # NOTE: The tagging property is NOT planned to be supported in the Metrics Evaluation.  Tagging can be achieved with explicit action_mappings.
     tagging:
       enabled: true # If false, then TAG_CHARACTER will not be an available action to ADMs unless added explicitly in actions block

--- a/test.yaml
+++ b/test.yaml
@@ -95,8 +95,8 @@ state:
             level: novice
         role: Infantry # The primary role a character has in the mission; controlled vocab includes Infantry, SEAL, Command, Intelligence, Medical, Specialist, Communications, etc.
       vitals:
-        conscious: true
-        avpu: UNRESPONSIVE # controlled vocab includes ALERT, VOICE, PAIN, UNRESPONSIVE; see https://www.firstresponse.org.uk/first-aid-az/3-general/first-aid/79-levels-of-response
+        conscious: false
+        avpu: PAIN # controlled vocab includes ALERT, VOICE, PAIN, UNRESPONSIVE; see https://www.firstresponse.org.uk/first-aid-az/3-general/first-aid/79-levels-of-response
         ambulatory: false
         mental_status: UNRESPONSIVE # controlled vocab includes AGONY, CALM, CONFUSED, SHOCK, UPSET, UNRESPONSIVE
         breathing: FAST # controlled vocab includes NORMAL, FAST, RESTRICTED, NONE
@@ -104,9 +104,12 @@ state:
         spo2: 92 # a percentage
       injuries:
         - name: Internal # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone
-          location: internal # controlled vocab includes forearm, calf, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, unspecified.  Most locations allow a left and right designation.
+          location: internal # controlled vocab includes forearm, calf, hand, leg, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, unspecified.  Most locations allow a left and right designation.
           status: hidden # controlled vocab: hidden, discoverable, discovered, treated, visible
           source_character: Civilian_01 # The character id of the person responsible for the injury
+        - name: Laceration # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone
+          location: left hand # controlled vocab includes forearm, calf, hand, leg, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, unspecified.  Most locations allow a left and right designation.
+          status: treated # controlled vocab: hidden, discoverable, discovered, treated, visible
     - id: Civilian_01
       name: Unknown civilian
       unstructured: >
@@ -189,6 +192,7 @@ scenes:
       - probe_id: adept-september-demo-probe-4
         description: How to tag Civilian
     restricted_actions: # These actions will not be returned in get_available_actions (not including END_SCENE)
+      - CHECK_BLOOD_OXYGEN
       - DIRECT_MOBILE_CHARACTERS
       - SEARCH
       - MOVE_TO_EVAC
@@ -229,7 +233,13 @@ scenes:
         choice: s1-p3-choice4
         kdma_association:
           Fairness: 0.2
-      ## NOTE: Similar tags for Civilian omitted for brevity 
+      ## NOTE: All Civilian tags result in the same probe response
+      - action_id: tag-civilian
+        action_type: TAG_CHARACTER
+        unstructured: Tag Civilian
+        character_id: Civilian_01
+        probe_id: adept-september-demo-probe-3
+        choice: s1-p4-choice1
       - action_id: action1
         action_type: SITREP
         unstructured: Ask Mike to provide SITREP # Roughly corresponds to ProbeOption's "value" field
@@ -299,6 +309,7 @@ scenes:
         - { type: Tourniquet, quantity: 1 } # Only 1 tourniquet left
   - index: 1
     end_scene_allowed: false
+    final_scene: true
     # NOTE: The tagging property is NOT planned to be supported in the Metrics Evaluation.  Tagging can be achieved with explicit action_mappings.
     tagging:
       reference: 0 # Re-use the tagging configuration from the specified scene index
@@ -340,7 +351,7 @@ scenes:
             spo2: 97 # a percentage
           injuries:
             - name: Burn # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone
-              location: unspecified # controlled vocab includes forearm, calf, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, unspecified.  Most locations allow a left and right designation.
+              location: unspecified # controlled vocab includes forearm, calf, hand, leg, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, unspecified.  Most locations allow a left and right designation.
               severity: substantial # controlled vocab: minor, moderate, substantial, major, extreme
               status: discoverable # controlled vocab: hidden, discoverable, discovered, treated, visible
         - id: Captain_01
@@ -389,6 +400,7 @@ scenes:
       - DIRECT_MOBILE_CHARACTERS
       - APPLY_TREATMENT
       - CHECK_ALL_VITALS
+      - CHECK_BLOOD_OXYGEN
       - CHECK_PULSE
       - CHECK_RESPIRATION
       - SEARCH
@@ -411,6 +423,3 @@ scenes:
     transitions:
       probes:
        - adept-september-demo-probe-5
-  - index: 2
-    end_scene_allowed: true
-    action_mapping: []

--- a/test.yaml
+++ b/test.yaml
@@ -310,7 +310,6 @@ scenes:
   - index: 1
     end_scene_allowed: false
     final_scene: true
-    persist_characters: true
     # NOTE: The tagging property is NOT planned to be supported in the Metrics Evaluation.  Tagging can be achieved with explicit action_mappings.
     tagging:
       reference: 0 # Re-use the tagging configuration from the specified scene index
@@ -319,6 +318,73 @@ scenes:
         unstructured: No mission parameters # mission is not required, but if it is provided, unstructured is required
         character_importance: # A list of pairs of character ids with an indicator of how mission-critical the character is
           - Captain_01: important # controlled vocab includes low, normal, important, priority, vip; must be kept consistent with demographics.mission_importance
+      characters:
+        - id: Marine_burns_01
+          name: Bob
+          unstructured: >
+            A 25 year-old male Marine hit by an IED. 
+            No obvious external injuries.
+          unstructured_postassess:
+            > # Unstructured text can change after assessment to reflect discovered injuries
+            A 25 year-old male Marine hit by an IED. 
+            No obvious external injuries, but burns over 50% of body.
+          rapport: neutral # A measure of closeness or affinity towards the player/medic. Controlled vocab: loathing, dislike, neutral, close, familial
+          demographics:
+            age: 25
+            sex: M
+            race: White # controlled vocab includes American Indian, White, Hispanic, Black, Asian, Pacific Islander
+            military_disposition: Allied US # controlled vocab includes Allied US, Allied, Civilian, Military Adversary, Non-Military Adversary
+            military_branch: US Marine Corps # controlled vocab includes US Army, US Navy, US Air Force, US Marine Corps, US Space Force, US Coast Guard
+            rank: E-2 # For controlled vocab, see "Paygrade" column of https://www.military.com/join-military/military-ranks-everything-you-need-know.html
+            rank_title: Private First Class # For controlled vocab, see "Rank" column of https://www.military.com/join-military/military-ranks-everything-you-need-know.html
+            skills: # Describes abilities a character can have; if not listed, assume no skill in the area
+              - skill_type: Combat # controlled vocab includes Medical, Combat, Specialist, Communications, Command
+                level: qualified # controlled vocab includes novice, qualified, competent, skilled, expert
+            role: Infantry # The role a character has in the mission; controlled vocab includes Infantry, SEAL, Command, Intelligence, Medical, Specialist, Communications, etc.
+          vitals:
+            conscious: true
+            avpu: ALERT # level of response; controlled vocab includes ALERT, VOICE, PAIN, UNRESPONSIVE; see https://www.firstresponse.org.uk/first-aid-az/3-general/first-aid/79-levels-of-response
+            ambulatory: true
+            mental_status: AGONY # controlled vocab includes AGONY, CALM, CONFUSED, SHOCK, UPSET, UNRESPONSIVE
+            breathing: FAST # controlled vocab includes NORMAL, FAST, RESTRICTED, NONE
+            heart_rate: FAST # controlled vocab includes NONE, FAINT, NORMAL, FAST
+            spo2: 97 # a percentage
+          injuries:
+            - name: Burn # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone
+              location: unspecified # controlled vocab includes forearm, calf, hand, leg, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, unspecified.  Most locations allow a left and right designation.
+              severity: substantial # controlled vocab: minor, moderate, substantial, major, extreme
+              status: discoverable # controlled vocab: hidden, discoverable, discovered, treated, visible
+        - id: Captain_01
+          name: Katie
+          unstructured: >
+            An uninjuried 30-40 YO female who escaped harm.
+            No obvious external injuries.
+          rapport: close # A measure of closeness or affinity towards the player/medic. Controlled vocab: loathing, dislike, neutral, close, familial
+          demographics:
+            age: 35
+            sex: F
+            race: White # controlled vocab includes American Indian, White, Hispanic, Black, Asian, Pacific Islander
+            military_disposition: Allied US # controlled vocab includes Allied US, Allied, Civilian, Military Adversary, Non-Military Adversary
+            military_branch: US Marine Corps # controlled vocab includes US Army, US Navy, US Air Force, US Marine Corps, US Space Force, US Coast Guard
+            rank: O-3 # For controlled vocab, see "Paygrade" column of https://www.military.com/join-military/military-ranks-everything-you-need-know.html
+            rank_title: Captain # For controlled vocab, see "Rank" column of https://www.military.com/join-military/military-ranks-everything-you-need-know.html
+            skills: # Describes abilities a character can have; if not listed, assume no skill in the area
+              - skill_type: Combat # controlled vocab includes Medical, Combat, Specialist, Communications, Command
+                level: skilled # controlled vocab includes novice, qualified, competent, skilled, expert
+              - skill_type: Command
+                level: competent
+              - skill_type: Communications
+                level: qualified
+            role: Command # The role a character has in the mission; controlled vocab includes Infantry, SEAL, Command, Intelligence, Medical, Specialist, Communications, etc.
+            mission_importance: important # controlled vocab includes low, normal, important, priority, vip; must be kept consistent with mission.character_importance
+          vitals:
+            conscious: true
+            avpu: ALERT # controlled vocab includes ALERT, VOICE, PAIN, UNRESPONSIVE; see https://www.firstresponse.org.uk/first-aid-az/3-general/first-aid/79-levels-of-response
+            ambulatory: true
+            mental_status: CALM # controlled vocab includes AGONY, CALM, CONFUSED, SHOCK, UPSET, UNRESPONSIVE
+            breathing: NORMAL # controlled vocab includes NORMAL, FAST, RESTRICTED, NONE
+            heart_rate: NORMAL # controlled vocab includes NONE, FAINT, NORMAL, FAST
+            spo2: 99 # a percentage
       environment:
         decision_environment:
           unstructured: >

--- a/test.yaml
+++ b/test.yaml
@@ -1,4 +1,4 @@
-id: adept-metrics-training-jungle-1
+id: adept-metrics-eval-jungle-1
 name: IED Explosion
 state:
   unstructured: >
@@ -70,6 +70,8 @@ state:
     - { type: Pain Medications, quantity: 2 }
     - { type: Splint, quantity: 2 }
     - { type: Blood, quantity: 5 }  # quantity is in units; no notion of blood type
+    - { type: Burn Dressing, quantity: 5 }
+    - { type: IV Bag, quantity: 3 }
   characters:
     - id: Mike # Internal name, can be same as name
       name: Mike # Name used in display/speech
@@ -99,11 +101,11 @@ state:
         mental_status: UNRESPONSIVE # controlled vocab includes AGONY, CALM, CONFUSED, SHOCK, UPSET, UNRESPONSIVE
         breathing: FAST # controlled vocab includes NORMAL, FAST, RESTRICTED, NONE
         heart_rate: FAST # controlled vocab includes NONE, FAINT, NORMAL, FAST
-        Spo2: 92 # a percentage
+        spo2: 92 # a percentage
       injuries:
         - name: Internal # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone
           location: internal # controlled vocab includes forearm, calf, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, unspecified.  Most locations allow a left and right designation.
-          status: hidden # controlled vocab: hidden, discoverable, visible (at runtime can change to discovered, treated)
+          status: hidden # controlled vocab: hidden, discoverable, discovered, treated, visible
           source_character: Civilian_01 # The character id of the person responsible for the injury
     - id: Civilian_01
       name: Unknown civilian
@@ -126,7 +128,7 @@ state:
         mental_status: CONFUSED # Like unresponsive, but could be an indication of non-English speaking; pairs with conscious=true
         breathing: NORMAL # controlled vocab includes NORMAL, FAST, RESTRICTED, NONE
         heart_rate: FAINT # controlled vocab includes NONE, FAINT, NORMAL, FAST
-        Spo2: 94 # a percentage
+        spo2: 94 # a percentage
 
 # - Each scene has associated state, including mission parameters, environment, characters, etc.
 # - Each scene has a set of actions that map to probe responses
@@ -234,21 +236,17 @@ scenes:
         character_id: Mike
         probe_id: adept-september-demo-probe-1
         choice: s1-p1-choice1
-        kdma_association:
-          Fairness: 0.5
-        condition_semantics: "and" # Can be "and", "or", or "not"
+        condition_semantics: not # 'not' semantics means that the probe is fired if all of the conditions are false
         conditions:
           # Action conditions are configured just like scene transitions below.  If the condition is met, the probe response is sent.
-          elapsed_time_gt: 30
-          elapsed_time_lt: 60
+          elapsed_time_gt: 3000
+          elapsed_time_lt: 5
       - action_id: action2
         action_type: CHECK_ALL_VITALS
         unstructured: Check Mike's vital signs
         character_id: Mike
         probe_id: adept-september-demo-probe-1
         choice: s1-p1-choice2
-        kdma_association:
-          Fairness: 0.3
       - action_id: action3
         action_type: APPLY_TREATMENT
         unstructured: Treat Mike's injury
@@ -257,24 +255,18 @@ scenes:
         parameters: { "treatment": "Tourniquet", "location": "right forearm" }
         probe_id: adept-september-demo-probe-1
         choice: s1-p1-choice3
-        kdma_association:
-          Fairness: 0.1
       - action_id: action4
         action_type: SITREP
         unstructured: Ask Civilian to provide SITREP
         character_id: Civilian_01
         probe_id: adept-september-demo-probe-2
         choice: s1-p2-choice1
-        kdma_association:
-          Fairness: 0.6
       - action_id: action5
         action_type: CHECK_ALL_VITALS
         unstructured: Check Civilian's vital signs
         character_id: Civilian_01
         probe_id: adept-september-demo-probe-2
         choice: s1-p2-choice2
-        kdma_association:
-          Fairness: 0.7
       - action_id: action6
         action_type: APPLY_TREATMENT
         unstructured: Treat Civilian's injury
@@ -284,9 +276,7 @@ scenes:
         parameters: { "treatment": "Tourniquet"}
         probe_id: adept-september-demo-probe-2
         choice: s1-p2-choice3
-        kdma_association:
-          Fairness: 0.9
-    transition_semantics: "and" # Can be "and", "or", or "not"
+    transition_semantics: or # Can be and, or, or not
     transitions: # This example shows different types of transitions; it's unlikely you'd use all of these in one scene
       elapsed_time_lt: 120
       elapsed_time_gt: 30
@@ -308,7 +298,7 @@ scenes:
       supplies: # Specifying this would mean that the scene would end when the specified supply reaches the specified quantity
         - { type: Tourniquet, quantity: 1 } # Only 1 tourniquet left
   - index: 1
-    end_scene_allowed: true
+    end_scene_allowed: false
     # NOTE: The tagging property is NOT planned to be supported in the Metrics Evaluation.  Tagging can be achieved with explicit action_mappings.
     tagging:
       reference: 0 # Re-use the tagging configuration from the specified scene index
@@ -347,12 +337,12 @@ scenes:
             mental_status: AGONY # controlled vocab includes AGONY, CALM, CONFUSED, SHOCK, UPSET, UNRESPONSIVE
             breathing: FAST # controlled vocab includes NORMAL, FAST, RESTRICTED, NONE
             heart_rate: FAST # controlled vocab includes NONE, FAINT, NORMAL, FAST
-            Spo2: 97 # a percentage
+            spo2: 97 # a percentage
           injuries:
             - name: Burn # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone
               location: unspecified # controlled vocab includes forearm, calf, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, unspecified.  Most locations allow a left and right designation.
               severity: substantial # controlled vocab: minor, moderate, substantial, major, extreme
-              status: discoverable # controlled vocab: hidden, discoverable, visible (at runtime can change to discovered, treated)
+              status: discoverable # controlled vocab: hidden, discoverable, discovered, treated, visible
         - id: Captain_01
           name: Katie
           unstructured: >
@@ -383,7 +373,7 @@ scenes:
             mental_status: CALM # controlled vocab includes AGONY, CALM, CONFUSED, SHOCK, UPSET, UNRESPONSIVE
             breathing: NORMAL # controlled vocab includes NORMAL, FAST, RESTRICTED, NONE
             heart_rate: NORMAL # controlled vocab includes NONE, FAINT, NORMAL, FAST
-            Spo2: 99 # a percentage
+            spo2: 99 # a percentage
       environment:
         decision_environment:
           unstructured: >
@@ -411,8 +401,6 @@ scenes:
         parameters: {"evac_id": "small_evac"}
         probe_id: adept-september-demo-probe-5
         choice: s1-p5-choice1
-        kdma_association:
-          Fairness: 0.2
       - action_id: action2
         action_type: MOVE_TO_EVAC
         unstructured: Move Bob to the road for transport
@@ -420,5 +408,9 @@ scenes:
         parameters: {"evac_id": "small_evac"}
         probe_id: adept-september-demo-probe-5
         choice: s1-p5-choice2
-        kdma_association:
-          Fairness: 0.7
+    transitions:
+      probes:
+       - adept-september-demo-probe-5
+  - index: 2
+    end_scene_allowed: true
+    action_mapping: []

--- a/test.yaml
+++ b/test.yaml
@@ -161,9 +161,6 @@ scenes:
   - index: 0
     # The scene with index = 0 uses the state defined at the scenario level
     end_scene_allowed: false
-    state:
-      unstructured: first scene
-      characters: []
     # NOTE: The tagging property is NOT planned to be supported in the Metrics Evaluation.  Tagging can be achieved with explicit action_mappings.
     tagging:
       enabled: true # If false, then TAG_CHARACTER will not be an available action to ADMs unless added explicitly in actions block

--- a/validator.py
+++ b/validator.py
@@ -79,7 +79,10 @@ class YamlValidator:
             self.logger.log(LogLevel.ERROR, "Error while loading in json dependency file. Please check the .env to make sure the location is correct and try again.\n\n" + str(e) + "\n")
         self.train_mode = train_mode
         api = copy.deepcopy(self.api_yaml)
-        self.allowed_supplies = api['components']['schemas']['SupplyTypeEnum']['enum'] if self.train_mode else ['Tourniquet', 'Pressure bandage', 'Hemostatic gauze', 'Decompression Needle', 'Nasopharyngeal airway', 'Pulse Oximeter', 'Pain Medications', 'Splint', 'Blood', 'IV Bag', 'Burn Dressing', 'Epi Pen', 'Vented Chest Seal']
+        self.allowed_supplies = copy.deepcopy(api['components']['schemas']['SupplyTypeEnum']['enum'])
+        if not self.train_mode:
+            for x in self.dep_json['trainingOnlySupplies']:
+                self.allowed_supplies.remove(x)
 
     def __del__(self):
         '''

--- a/validator.py
+++ b/validator.py
@@ -818,7 +818,7 @@ class YamlValidator:
                 # make sure the index exists in the allowed values dict
                 if ind not in allowed_vals:
                     where_vals_found = '.'.join(allowed_loc_0) if ind==0 else '.'.join(allowed_loc_other).replace('scenes[]', f'scenes[{ind}]')
-                    if where_vals_found not in missing_locs:
+                    if where_vals_found not in missing_locs and not self.get_value_at_key(where_vals_found.split('.')[:1] + ['persist_characters'], copy.deepcopy(self.loaded_yaml)):
                         missing_locs.append(where_vals_found)
                         self.logger.log(LogLevel.WARN, "Path '" + str(where_vals_found) + "' does not exist.")
                         self.missing_keys += 1

--- a/validator.py
+++ b/validator.py
@@ -421,7 +421,7 @@ class YamlValidator:
         self.character_matching()
         self.verify_uniqueness()
         self.verify_allowed_actions()
-        self.final_scene_allowed()
+        self.final_scene_true()
 
 
     def simple_requirements(self):
@@ -981,16 +981,18 @@ class YamlValidator:
                 self.logger.log(LogLevel.WARN, "Value of 'state.mission.character_importance' is missing pair ('" + k + "', '" + str(pairs[k]) + "')")
                 self.missing_keys += 1         
 
-    def final_scene_allowed(self):
+
+    def final_scene_true(self):
         '''
-        Looks through the yaml file to make sure that at least one scene has final_scene_allowed=true
+        Looks through the yaml file to make sure that at least one scene has final_scene=true
         '''
         data = copy.deepcopy(self.loaded_yaml)
         scenes = data['scenes']
         for i in range(0, len(scenes)):
-            if 'final_scene_allowed' in scenes[i] and scenes[i]['final_scene_allowed'] == True:
+            if 'final_scene' in scenes[i] and scenes[i]['final_scene'] == True:
                 return
-        self.logger.log(LogLevel.CRITICAL_INFO, "Key 'final_scene_allowed' should probably have value 'true' in at least one scene, but does not.")
+        self.logger.log(LogLevel.CRITICAL_INFO, "Key 'final_scene' should probably have value 'true' in at least one scene, but does not.")
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='ITM - YAML Validator', usage='validator.py [-h] [-u [-f PATH] | -f PATH ]')

--- a/validator.py
+++ b/validator.py
@@ -125,7 +125,7 @@ class YamlValidator:
                 required.remove('characters')
 
         if level_name == 'supplies':
-            if to_validate.get('type') not in self.allowed_supplies:
+            if to_validate.get('type') not in self.allowed_supplies and to_validate.get('quantity') > 0:
                 self.logger.log(LogLevel.WARN, f"Since eval mode is true, supplies must only be one of {self.allowed_supplies}, but '{to_validate.get('type')}' was found.")
                 self.invalid_values += 1
 
@@ -995,11 +995,11 @@ class YamlValidator:
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='ITM - YAML Validator', usage='validator.py [-h] [-u [-f PATH] | -f PATH ]')
+    parser = argparse.ArgumentParser(description='ITM - YAML Validator')
 
     parser.add_argument('-f', '--filepath', dest='path', type=str, help='The path to the yaml file. Required if -u is not specified.')
     parser.add_argument('-u', '--update', dest='update', action='store_true', help='Switch to update the api files or not. Required if -f is not specified.')
-    parser.add_argument('-t', '--train', dest='train', action='store_true', help="Validate a training scenario yaml (default)")
+    parser.add_argument('-t', '--train', dest='train', action='store_true', help="Validate a training scenario yaml")
     args = parser.parse_args()
     if args.update:
         generator = ApiGenerator()

--- a/validator.py
+++ b/validator.py
@@ -421,6 +421,7 @@ class YamlValidator:
         self.character_matching()
         self.verify_uniqueness()
         self.verify_allowed_actions()
+        self.final_scene_allowed()
 
 
     def simple_requirements(self):
@@ -980,6 +981,17 @@ class YamlValidator:
                 self.logger.log(LogLevel.WARN, "Value of 'state.mission.character_importance' is missing pair ('" + k + "', '" + str(pairs[k]) + "')")
                 self.missing_keys += 1         
 
+    def final_scene_allowed(self):
+        '''
+        Looks through the yaml file to make sure that at least one scene has final_scene_allowed=true
+        '''
+        data = copy.deepcopy(self.loaded_yaml)
+        scenes = data['scenes']
+        for i in range(0, len(scenes)):
+            if 'final_scene_allowed' in scenes[i] and scenes[i]['final_scene_allowed'] == True:
+                return
+        self.logger.log(LogLevel.WARN, "Key 'final_scene_allowed' must have value 'true' in at least one scene, but does not.")
+        self.invalid_values += 1
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='ITM - YAML Validator', usage='validator.py [-h] [-u [-f PATH] | -f PATH ]')

--- a/validator.py
+++ b/validator.py
@@ -990,8 +990,7 @@ class YamlValidator:
         for i in range(0, len(scenes)):
             if 'final_scene_allowed' in scenes[i] and scenes[i]['final_scene_allowed'] == True:
                 return
-        self.logger.log(LogLevel.WARN, "Key 'final_scene_allowed' must have value 'true' in at least one scene, but does not.")
-        self.invalid_values += 1
+        self.logger.log(LogLevel.CRITICAL_INFO, "Key 'final_scene_allowed' should probably have value 'true' in at least one scene, but does not.")
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='ITM - YAML Validator', usage='validator.py [-h] [-u [-f PATH] | -f PATH ]')

--- a/validator.py
+++ b/validator.py
@@ -442,7 +442,7 @@ class YamlValidator:
             # check through each element of the array for keys
             if '[]' in k:
                 simple_k = k.split('[]')[0]
-                if simple_k in data:
+                if data is not None and simple_k in data:
                     data = data[simple_k]
                     data = data if data is not None else []
                     for j in range(len(data)):
@@ -455,7 +455,7 @@ class YamlValidator:
                     skip = True
                     break
             else:
-                if k in data:
+                if data is not None and k in data:
                     data = data[k]
                 else:
                     # key is not here, don't keep searching

--- a/validator.py
+++ b/validator.py
@@ -79,7 +79,7 @@ class YamlValidator:
             self.logger.log(LogLevel.ERROR, "Error while loading in json dependency file. Please check the .env to make sure the location is correct and try again.\n\n" + str(e) + "\n")
         self.train_mode = train_mode
         api = copy.deepcopy(self.api_yaml)
-        self.allowed_supplies = api['components']['schemas']['SupplyTypeEnum']['enum'] if self.train_mode else ['Tourniquet', 'Pressure bandage', 'Hemostatic gauze', 'Decompression Needle', 'Nasopharyngeal airway', 'Pulse Oximeter', 'Pain Medications', 'Splint', 'Blood', 'IV Bag', 'Burn Dressing', 'Epi Pen']
+        self.allowed_supplies = api['components']['schemas']['SupplyTypeEnum']['enum'] if self.train_mode else ['Tourniquet', 'Pressure bandage', 'Hemostatic gauze', 'Decompression Needle', 'Nasopharyngeal airway', 'Pulse Oximeter', 'Pain Medications', 'Splint', 'Blood', 'IV Bag', 'Burn Dressing', 'Epi Pen', 'Vented Chest Seal']
 
     def __del__(self):
         '''

--- a/validator.py
+++ b/validator.py
@@ -79,7 +79,7 @@ class YamlValidator:
             self.logger.log(LogLevel.ERROR, "Error while loading in json dependency file. Please check the .env to make sure the location is correct and try again.\n\n" + str(e) + "\n")
         self.train_mode = train_mode
         api = copy.deepcopy(self.api_yaml)
-        self.allowed_supplies = api['components']['schemas']['SupplyTypeEnum']['enum'] if self.train_mode else ['Tourniquet', 'Pressure bandage', 'Hemostatic gauze', 'Decompression Needle', 'Nasopharyngeal airway', 'Pulse Oximeter', 'Pain Medications', 'Splint', 'Blood', 'IV Bag', 'Burn Dressing']
+        self.allowed_supplies = api['components']['schemas']['SupplyTypeEnum']['enum'] if self.train_mode else ['Tourniquet', 'Pressure bandage', 'Hemostatic gauze', 'Decompression Needle', 'Nasopharyngeal airway', 'Pulse Oximeter', 'Pain Medications', 'Splint', 'Blood', 'IV Bag', 'Burn Dressing', 'Epi Pen']
 
     def __del__(self):
         '''


### PR DESCRIPTION
- No repeated index values in scenes[].
- All characters need vitals
- Verify that MOVE_TO_EVAC evac_id is in the state
- Ensure that none of the action_types in the action_mappings are also in restricted_actions
- Remove the restriction on setting character.visited
- Remove the restriction on requiring characters as long as persist_characters is True
- Update YAML (for, e.g., persist_characters, etc.)
- Allow all injury statuses.
- Allow unconscious patients to have avpu of “UNRESPONSIVE” or “PAIN”.
- Update allowed injury locations in sync with what we support in the simulator
- Add a flag to say if it's a training (sim) scenario
  - Forbid training-only supplies in eval scenarios (Blanket, Epi Pen, Vented Chest Seal)
- Added INFO message if there’s no configured final_scene