### PR TITLE
Itm 441 env type changes

### DIFF
--- a/api_files/generator.py
+++ b/api_files/generator.py
@@ -137,9 +137,6 @@ class ApiGenerator:
         # sim environment must have unstructured
         new_api['components']['schemas']['SimEnvironment']['required'] = ['unstructured']
 
-        # sim environment does not have type
-        del new_api['components']['schemas']['SimEnvironment']['properties']['type']
-
         # aid delay can be empty, but id is still required
         new_api['components']['schemas']['AidDelay']['required'] = ['id']
 

--- a/api_files/state_changes.yaml
+++ b/api_files/state_changes.yaml
@@ -709,6 +709,8 @@ components:
           type: number
         terrain:
           $ref: '#/components/schemas/TerrainTypeEnum'
+        type:
+          $ref: '#/components/schemas/SimEnvironmentTypeEnum'
         unstructured:
           description: Natural language, plain text description of the environment
           example: It was a dark and stormy night.

--- a/validator.py
+++ b/validator.py
@@ -988,7 +988,7 @@ class YamlValidator:
                 new_type = scene['state']['environment']['sim_environment'].get('type', None)
                 if new_type is not None and new_type != orig_type:
                     self.warning_count += 1
-                    self.logger.log(LogLevel.INFO, f"Key 'type' should not be redefined in scene states, but changes from '{orig_type}' to '{new_type}' in scene '{scene['id']}'. This redefinition will be ignored by the adm server.")
+                    self.logger.log(LogLevel.INFO, f"Key 'type' should not be redefined in scene states, but changes from '{orig_type}' to '{new_type}' in scene '{scene['id']}'. This redefinition will be ignored.")
 
 
 if __name__ == '__main__':

--- a/validator.py
+++ b/validator.py
@@ -45,6 +45,7 @@ class YamlValidator:
     out_of_range = 0
     invalid_keys = 0
     empty_levels = 0
+    warning_count = 0
     train_mode = False
     allowed_supplies = []
 
@@ -424,6 +425,7 @@ class YamlValidator:
         self.verify_uniqueness()
         self.verify_allowed_actions()
         self.check_first_scene()
+        self.check_scene_env_type()
 
 
     def simple_requirements(self):
@@ -973,6 +975,21 @@ class YamlValidator:
             self.logger.log(LogLevel.WARN, "Key 'state' is not allowed in the first scene")
             self.invalid_keys += 1
 
+    def check_scene_env_type(self):
+        '''
+        Checks to make sure if a scene state defines sim_environment, the type is not 
+        different from the type defined in scenario.sim_environment
+        '''
+        data = copy.deepcopy(self.loaded_yaml)
+        orig_type = data['state']['environment']['sim_environment']['type']
+        scenes = data['scenes']
+        for scene in scenes:
+            if 'state' in scene and 'environment' in scene['state'] and 'sim_environment' in scene['state']['environment']:
+                new_type = scene['state']['environment']['sim_environment'].get('type', None)
+                if new_type is not None and new_type != orig_type:
+                    self.warning_count += 1
+                    self.logger.log(LogLevel.INFO, f"Key 'type' should not be redefined in scene states, but changes from '{orig_type}' to '{new_type}' in scene '{scene['id']}'. This redefinition will be ignored by the adm server.")
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='ITM - YAML Validator')
@@ -1003,7 +1020,9 @@ if __name__ == '__main__':
     validator.logger.log(LogLevel.CRITICAL_INFO, ("\033[92m" if validator.out_of_range == 0 else "\033[91m") + "Invalid Values (out of range): " + str(validator.out_of_range))
     validator.logger.log(LogLevel.CRITICAL_INFO, ("\033[92m" if validator.empty_levels == 0 else "\033[91m") + "Properties Missing Data (empty level): " + str(validator.empty_levels))
     total_errors = validator.missing_keys + validator.wrong_types + validator.invalid_keys + validator.invalid_values + validator.empty_levels + validator.out_of_range
+    print()
     validator.logger.log(LogLevel.CRITICAL_INFO, ("\033[92m" if total_errors == 0 else "\033[91m") + "Total Errors: " + str(total_errors))
+    validator.logger.log(LogLevel.CRITICAL_INFO, ("\033[92m" if validator.warning_count == 0 else "\033[91m") + "Warnings: " + str(validator.warning_count))
     if total_errors == 0:
         validator.logger.log(LogLevel.CRITICAL_INFO, "\033[92m" + file + " is valid!")
     else:


### PR DESCRIPTION
The validator was (correctly) erroring when type was redefined inside a scene state. However, we decided that since type is technically required in sim_environment within a state, we should allow them to redefine it, as long as it doesn't change from the original scene type. We will just give them a warning that the redefinition will be ignored. 

A new warning log has been added at the bottom for "info" logs, separate from total errors. If a file has warnings (info logs) and not errors (warning logs, yes I know it's confusing and we might change it sometime), it should still say that it is valid