### PR TITLE
ITM-528: More Updates for Dry Run Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Any supply name placed in this array will be excluded from the allowed supplies 
     * This does not include "normal", which is the default level of importance. For example, a character may not specify `mission_importance` and `character_importance` may explicitly specify the character with importance "normal", or a character may specify `mission_importance` with "normal" and `character_importance` may not list that character 
 * If the scene is the first scene, `scenes[].state` should _not_ be provided
 * No blanket can appear on the character at the start. 
-
+* Quantized injuries (where `treatments_required` > 1) aren't supported for injuries that aren't successfully treated by hemostatic gauze or pressure bandage.
 
 #### Message/Event Rules
 * `source` is recommended for all events

--- a/README.md
+++ b/README.md
@@ -216,13 +216,14 @@ When not running in training mode (-t), additional checks are implemented:
 | `Open Abdominal Wound` | `stomach` |
 | `Ear Bleed` | `left face` |
 | `Asthmatic` | `internal` |
+| `Abrasion` | `left face`, `right face`, `left thigh`, `right thigh`, `left calf`, `right calf`, `left bicep`, `right bicep`, `left forearm`, `right forearm` |
 | `Laceration` | `left face`, `left forearm`, `right forearm`, `left stomach`, `left thigh`, `right thigh`, `left calf`, `right calf`, `left wrist`, `right wrist` |
-| `Puncture` | `left neck`, `right neck`, `left bicep`, `right bicep`, `left shoulder`, `right shoulder`, `left stomach`, `right stomach`, `left side`, `right side`, `left thigh`, `right thigh`, `left chest`, `right chest`, `center chest`, `left calf`, `right calf` |
+| `Puncture` | `left neck`, `right neck`, `left bicep`, `right bicep`, `left forearm`, `right forearm`, `left shoulder`, `right shoulder`, `left stomach`, `right stomach`, `left side`, `right side`, `left thigh`, `right thigh`, `left chest`, `right chest`, `center chest`, `left calf`, `right calf` |
 | `Shrapnel` | `left face`, `right face`, `left calf`, `right calf` |
 | `Chest Collapse` | `left chest`, `right chest` |
 | `Amputation` | `left wrist`, `right wrist`, `left calf`, `right calf`, `left thigh`, `right thigh` |
 | `Burn` | `right forearm`, `left forearm`, `right calf`, `left calf`, `right thigh`, `left thigh`, `right side`, `left side`, `right chest`, `left chest`, `neck`, `right bicep`, `left biecp` |
-| `Broken Bone` | `right leg`, `left leg`, `right shoulder`, `left shoulder` |
+| `Broken Bone` | `right leg`, `left leg`, `right shoulder`, `left shoulder`, `right wrist`, `left wrist` |
 | `Internal` | `internal`, `unspecified` | 
 
 #### Military Branches, Ranks, and Rank Titles

--- a/api_files/api.yaml
+++ b/api_files/api.yaml
@@ -2,10 +2,10 @@ openapi: 3.0.3
 info:
   title: ITM TA3 API
   description: |-
-    This is the specification of the TA3 API for In The Moment (ITM).  Currently, the Evaluation API for TA2 supports functionality for the September milestone.
+    This is the specification of the TA3 API for In The Moment (ITM).  Currently, the Evaluation API for TA2 supports functionality for the Dry Run Evaluation.
 
-    The API is based on the OpenAPI 3.0 specification.
-  version: 0.3.0
+    The API is based on the OpenAPI 3.0.3 specification.
+  version: 0.3.2
 servers:
   - url: /
 tags:
@@ -495,23 +495,40 @@ components:
           - value: 0.5
             kdma: fairness
         id: id
+    KDE_Data:
+      type: object
+      description: KDE Objects representing a KDMA Measurement
+      required:
+        - kde
+        - label
+      properties:
+        kde:
+          type: string
+          description: sklearn.neighbors.KernelDensity serialized to base64 string
+        label:
+          type: string
+          description: Label for this KDE
     KDMA_Value:
       required:
         - kdma
-        - value
       type: object
-      description: a KDMA and its value
+      description: Single KDMA value with values between 0 and 1, or a kernel density estimate of the KDMA value.
       properties:
         kdma:
           type: string
-          description: KDMA name
+          description: Name of KDMA
           example: mission
         value:
           type: number
           format: float
-          description: target alignment value
+          description: Numeric score for a given KDMA, 0-1 scale
           minimum: 0.0
           maximum: 1.0
+        kdes:
+          type: object
+          description: A character id with an indicator of how mission-critical that character is
+          additionalProperties:
+            $ref: "#/components/schemas/KDE_Data"
       example:
         value: 0.8
         kdma: mission
@@ -1793,6 +1810,7 @@ components:
         - Amputation
         - Burn
         - Broken Bone
+        - Abrasion
         - Internal
         - Traumatic Brain Injury
         - Open Abdominal Wound

--- a/api_files/dependencies.json
+++ b/api_files/dependencies.json
@@ -491,6 +491,20 @@
                     "left face"
                 ]
             },
+            "Abrasion": {
+                "state.characters[].injuries[].location": [
+                    "left face",
+                    "right face",
+                    "left thigh",
+                    "right thigh",
+                    "left calf",
+                    "right calf",
+                    "left bicep",
+                    "right bicep",
+                    "left forearm",
+                    "right forearm"
+                ]
+            },
             "Asthmatic": {
                 "state.characters[].injuries[].location": [
                     "internal"
@@ -516,6 +530,8 @@
                     "right neck",
                     "left bicep",
                     "right bicep",
+                    "left forearm",
+                    "right forearm",
                     "left shoulder",
                     "right shoulder",
                     "left stomach",
@@ -576,6 +592,8 @@
                 "state.characters[].injuries[].location": [
                     "right shoulder",
                     "left shoulder",
+                    "left wrist",
+                    "right wrist",
                     "left leg",
                     "right leg"
                 ]
@@ -603,6 +621,20 @@
                     "left face"
                 ]
             },
+            "Abrasion": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "left face",
+                    "right face",
+                    "left thigh",
+                    "right thigh",
+                    "left calf",
+                    "right calf",
+                    "left bicep",
+                    "right bicep",
+                    "left forearm",
+                    "right forearm"
+                ]
+            },
             "Asthmatic": {
                 "scenes[].state.characters[].injuries[].location": [
                     "internal"
@@ -628,6 +660,8 @@
                     "right neck",
                     "left bicep",
                     "right bicep",
+                    "left forearm",
+                    "right forearm",
                     "left shoulder",
                     "right shoulder",
                     "left stomach",
@@ -688,6 +722,8 @@
                 "scenes[].state.characters[].injuries[].location": [
                     "right shoulder",
                     "left shoulder",
+                    "left wrist",
+                    "right wrist",
                     "left leg",
                     "right leg"
                 ]

--- a/api_files/dependencies.json
+++ b/api_files/dependencies.json
@@ -93,7 +93,7 @@
                     "value": "Burn"
                 },
                 "required": [
-                    "state.characters[].injuries[].severity"
+                    "scenes[].state.characters[].injuries[].severity"
                 ]
             }
         ],

--- a/api_files/dependencies.json
+++ b/api_files/dependencies.json
@@ -57,6 +57,16 @@
                 ]
             }
         ],
+        "scenes[].state.characters[].demographics.military_disposition": [
+            {
+                "conditions": {
+                    "value": "Allied US"
+                },
+                "required": [
+                    "scenes[].state.characters[].demographics.military_branch"
+                ]
+            }
+        ],
         "scenes[].transitions": [
             {
                 "conditions": {
@@ -68,6 +78,16 @@
             }
         ],
         "state.characters[].injuries[].name": [
+            {
+                "conditions": {
+                    "value": "Burn"
+                },
+                "required": [
+                    "state.characters[].injuries[].severity"
+                ]
+            }
+        ],
+        "scenes[].state.characters[].injuries[].name": [
             {
                 "conditions": {
                     "value": "Burn"
@@ -352,6 +372,48 @@
                 ]
             }
         ],
+        "scenes[].state.characters[].demographics.military_disposition": [
+            {
+                "conditions": {
+                    "value": "Allied"
+                },
+                "forbid": [
+                    "scenes[].state.characters[].demographics.military_branch"
+                ]
+            },
+            {
+                "conditions": {
+                    "value": "Civilian"
+                },
+                "forbid": [
+                    "scenes[].state.characters[].demographics.military_branch"
+                ]
+            },
+            {
+                "conditions": {
+                    "value": "Military Adversary"
+                },
+                "forbid": [
+                    "scenes[].state.characters[].demographics.military_branch"
+                ]
+            },
+            {
+                "conditions": {
+                    "value": "Military Neutral"
+                },
+                "forbid": [
+                    "scenes[].state.characters[].demographics.military_branch"
+                ]
+            },
+            {
+                "conditions": {
+                    "value": "Non-Military Adversary"
+                },
+                "forbid": [
+                    "scenes[].state.characters[].demographics.military_branch"
+                ]
+            }
+        ],
         "state.characters[].demographics.military_branch": [
             {
                 "conditions": {
@@ -360,6 +422,17 @@
                 "forbid": [
                     "state.characters[].demographics.rank",
                     "state.characters[].demographics.rank_title"
+                ]
+            }
+        ],
+        "scenes[].state.characters[].demographics.military_branch": [
+            {
+                "conditions": {
+                    "exists": false
+                },
+                "forbid": [
+                    "scenes[].state.characters[].demographics.rank",
+                    "scenes[].state.characters[].demographics.rank_title"
                 ]
             }
         ],
@@ -509,6 +582,118 @@
             },
             "Internal": {
                 "state.characters[].injuries[].location": [
+                    "internal",
+                    "unspecified"
+                ]
+            }
+        },
+        "scenes[].state.characters[].injuries[].name": {
+            "Traumatic Brain Injury": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "head"
+                ]
+            },
+            "Open Abdominal Wound": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "stomach"
+                ]
+            },
+            "Ear Bleed": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "left face"
+                ]
+            },
+            "Asthmatic": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "internal"
+                ]
+            },
+            "Laceration": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "left face",
+                    "left forearm",
+                    "right forearm",
+                    "left stomach",
+                    "left thigh",
+                    "right thigh",
+                    "left calf",
+                    "right calf",
+                    "left hand",
+                    "right hand"
+                ]
+            },
+            "Puncture": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "left neck",
+                    "right neck",
+                    "left bicep",
+                    "right bicep",
+                    "left shoulder",
+                    "right shoulder",
+                    "left stomach",
+                    "right stomach",
+                    "left side",
+                    "right side",
+                    "left thigh",
+                    "right thigh",
+                    "left chest",
+                    "right chest",
+                    "center chest",
+                    "left calf",
+                    "right calf"
+                ]
+            },
+            "Shrapnel": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "left face",
+                    "right face",
+                    "left calf",
+                    "right calf"
+                ]
+            },
+            "Chest Collapse": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "left chest",
+                    "right chest"
+                ]
+            },
+            "Amputation": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "left wrist",
+                    "right wrist",
+                    "left calf",
+                    "right calf",
+                    "left thigh",
+                    "right thigh"
+                ]
+            },
+            "Burn": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "right forearm",
+                    "left forearm",
+                    "right calf",
+                    "left calf",
+                    "right thigh",
+                    "left thigh",
+                    "right side",
+                    "left side",
+                    "right chest",
+                    "left chest",
+                    "left bicep",
+                    "right bicep",
+                    "neck"
+                ]
+            },
+            "Broken Bone": {
+                "scenes[].state.characters[].injuries[].location": [
+                    "right shoulder",
+                    "left shoulder",
+                    "left leg",
+                    "right leg"
+                ]
+            },
+            "Internal": {
+                "scenes[].state.characters[].injuries[].location": [
                     "internal",
                     "unspecified"
                 ]
@@ -819,6 +1004,335 @@
                     "O-10"
                 ],
                 "state.characters[].demographics.rank_title": [
+                    "Specialist 1",
+                    "Specialist 2",
+                    "Specialist 3",
+                    "Specialist 4",
+                    "Staff Sergeant",
+                    "Technical Sergeant",
+                    "Master Sergeant",
+                    "Senior Master Sergeant",
+                    "Chief Master Sergeant",
+                    "Chief Master Sergeant of the Space Force",
+                    "2nd Lieutenant",
+                    "1st Lieutenant",
+                    "Captain",
+                    "Major",
+                    "Lieutenant Colonel",
+                    "Colonel",
+                    "Brigadier General",
+                    "Major General",
+                    "Lieutenant General",
+                    "Chief of Space Operations",
+                    "General"
+                ]
+            }
+        },
+        "scenes[].state.characters[].demographics.military_branch": {
+            "US Army": {
+                "scenes[].state.characters[].demographics.rank": [
+                    "E-1",
+                    "E-2",
+                    "E-3",
+                    "E-4",
+                    "E-5",
+                    "E-6",
+                    "E-7",
+                    "E-8",
+                    "E-9",
+                    "E-9 (special)",
+                    "W-1",
+                    "W-2",
+                    "W-3",
+                    "W-4",
+                    "W-5",
+                    "O-1",
+                    "O-2",
+                    "O-3",
+                    "O-4",
+                    "O-5",
+                    "O-6",
+                    "O-7",
+                    "O-8",
+                    "O-9",
+                    "O-10"
+                ],
+                "scenes[].state.characters[].demographics.rank_title": [
+                    "Private (Recruit)",
+                    "Private",
+                    "Private First Class",
+                    "Specialist",
+                    "Corporal",
+                    "Sergeant",
+                    "Staff Sergeant",
+                    "Sergeant First Class",
+                    "Master Sergeant",
+                    "First Sergeant",
+                    "Sergeant Major",
+                    "Command Sergeant Major",
+                    "Sergeant Major of the Army",
+                    "Warrant Officer 1",
+                    "Chief Warrant Officer 2",
+                    "Chief Warrant Officer 3",
+                    "Chief Warrant Officer 4",
+                    "Chief Warrant Officer 5",
+                    "2nd Lieutenant",
+                    "1st Lieutenant",
+                    "Captain",
+                    "Major",
+                    "Lieutenant Colonel",
+                    "Colonel",
+                    "Brigadier General",
+                    "Major General",
+                    "Lieutenant General",
+                    "Army Chief of Staff (special)",
+                    "General"
+                ]
+            },
+            "US Air Force": {
+                "scenes[].state.characters[].demographics.rank": [
+                    "E-1",
+                    "E-2",
+                    "E-3",
+                    "E-4",
+                    "E-5",
+                    "E-6",
+                    "E-7",
+                    "E-8",
+                    "E-9",
+                    "Special",
+                    "O-1",
+                    "O-2",
+                    "O-3",
+                    "O-4",
+                    "O-5",
+                    "O-6",
+                    "O-7",
+                    "O-8",
+                    "O-9",
+                    "O-10"
+                ],
+                "scenes[].state.characters[].demographics.rank_title": [
+                    "Airman Basic",
+                    "Airman",
+                    "Airman First Class",
+                    "Senior Airman",
+                    "Staff Sergeant",
+                    "Technical Sergeant",
+                    "Master Sergeant",
+                    "Senior Master Sergeant",
+                    "First Sergeant / Chief Master Sergeant",
+                    "Chief Master Sergeant of the Air Force",
+                    "2nd Lieutenant",
+                    "1st Lieutenant",
+                    "Captain",
+                    "Major",
+                    "Lieutenant Colonel",
+                    "Colonel",
+                    "Brigadier General",
+                    "Major General",
+                    "Lieutenant General",
+                    "Air Force Chief of Staff (special)",
+                    "General"
+                ]
+            },
+            "US Navy": {
+                "scenes[].state.characters[].demographics.rank": [
+                    "E-1",
+                    "E-2",
+                    "E-3",
+                    "E-4",
+                    "E-5",
+                    "E-6",
+                    "E-7",
+                    "E-8",
+                    "E-9",
+                    "Special (Navy)",
+                    "W-1",
+                    "W-2",
+                    "W-3",
+                    "W-4",
+                    "W-5",
+                    "O-1",
+                    "O-2",
+                    "O-3",
+                    "O-4",
+                    "O-5",
+                    "O-6",
+                    "O-7",
+                    "O-8",
+                    "O-9",
+                    "O-10"
+                ],
+                "scenes[].state.characters[].demographics.rank_title": [
+                    "Seaman Recruit",
+                    "Seaman Apprentice",
+                    "Seaman",
+                    "Petty Officer Third Class",
+                    "Petty Officer Second Class",
+                    "Petty Officer First Class",
+                    "Chief Petty Officer",
+                    "Senior Chief Petty Officer",
+                    "Master Chief Petty Officer",
+                    "Master Chief Petty Officer of the Navy",
+                    "Warrant Officer 1",
+                    "Chief Warrant Officer 2",
+                    "Chief Warrant Officer 3",
+                    "Chief Warrant Officer 4",
+                    "Chief Warrant Officer",
+                    "Ensign",
+                    "Lieutenant, Junior Grade",
+                    "Lieutenant",
+                    "Lieutenant Commander",
+                    "Commander",
+                    "Captain",
+                    "Rear Admiral (Lower Half)",
+                    "Rear Admiral (Upper Half)",
+                    "Vice Admiral",
+                    "Chief of Naval Operations (special)",
+                    "Admiral"
+                ]
+            },
+            "US Coast Guard": {
+                "scenes[].state.characters[].demographics.rank": [
+                    "E-1",
+                    "E-2",
+                    "E-3",
+                    "E-4",
+                    "E-5",
+                    "E-6",
+                    "E-7",
+                    "E-8",
+                    "E-9",
+                    "Special (Coast Guard)",
+                    "W-1",
+                    "W-2",
+                    "W-3",
+                    "W-4",
+                    "W-5",
+                    "O-1",
+                    "O-2",
+                    "O-3",
+                    "O-4",
+                    "O-5",
+                    "O-6",
+                    "O-7",
+                    "O-8",
+                    "O-9",
+                    "O-10"
+                ],
+                "scenes[].state.characters[].demographics.rank_title": [
+                    "Seaman Recruit",
+                    "Seaman Apprentice",
+                    "Seaman",
+                    "Petty Officer Third Class",
+                    "Petty Officer Second Class",
+                    "Petty Officer First Class",
+                    "Chief Petty Officer",
+                    "Senior Chief Petty Officer",
+                    "Master Chief Petty Officer",
+                    "Master Chief Petty Officer of the Coast Guard",
+                    "Warrant Officer 1",
+                    "Chief Warrant Officer 2",
+                    "Chief Warrant Officer 3",
+                    "Chief Warrant Officer 4",
+                    "Chief Warrant Officer",
+                    "Ensign",
+                    "Lieutenant, Junior Grade",
+                    "Lieutenant",
+                    "Lieutenant Commander",
+                    "Commander",
+                    "Captain",
+                    "Rear Admiral (Lower Half)",
+                    "Rear Admiral (Upper Half)",
+                    "Vice Admiral",
+                    "Commandant of the Coast Guard (special)",
+                    "Admiral"
+                ]
+            },
+            "US Marine Corps": {
+                "scenes[].state.characters[].demographics.rank": [
+                    "E-1",
+                    "E-2",
+                    "E-3",
+                    "E-4",
+                    "E-5",
+                    "E-6",
+                    "E-7",
+                    "E-8",
+                    "E-9",
+                    "Special",
+                    "W-1",
+                    "W-2",
+                    "W-3",
+                    "W-4",
+                    "W-5",
+                    "O-1",
+                    "O-2",
+                    "O-3",
+                    "O-4",
+                    "O-5",
+                    "O-6",
+                    "O-7",
+                    "O-8",
+                    "O-9",
+                    "O-10"
+                ],
+                "scenes[].state.characters[].demographics.rank_title": [
+                    "Private",
+                    "Private First Class",
+                    "Lance Corporal",
+                    "Corporal",
+                    "Sergeant",
+                    "Staff Sergeant",
+                    "Gunnery Sergeant",
+                    "Master Sergeant",
+                    "First Sergeant",
+                    "Master Gunnery Sergeant",
+                    "Sergeant Major",
+                    "Sergeant Major of the Marine Corps",
+                    "Warrant Officer",
+                    "Chief Warrant Officer 2",
+                    "Chief Warrant Officer 3",
+                    "Chief Warrant Officer 4",
+                    "Chief Warrant Officer 5",
+                    "2nd Lieutenant",
+                    "1st Lieutenant",
+                    "Captain",
+                    "Major",
+                    "Lieutenant Colonel",
+                    "Colonel",
+                    "Brigadier General",
+                    "Major General",
+                    "Lieutenant General",
+                    "Commandant of the Marine Corps",
+                    "General"
+                ]
+            },
+            "US Space Force": {
+                "scenes[].state.characters[].demographics.rank": [
+                    "E-1",
+                    "E-2",
+                    "E-3",
+                    "E-4",
+                    "E-5",
+                    "E-6",
+                    "E-7",
+                    "E-8",
+                    "E-9",
+                    "Special",
+                    "O-1",
+                    "O-2",
+                    "O-3",
+                    "O-4",
+                    "O-5",
+                    "O-6",
+                    "O-7",
+                    "O-8",
+                    "O-9",
+                    "O-10"
+                ],
+                "scenes[].state.characters[].demographics.rank_title": [
                     "Specialist 1",
                     "Specialist 2",
                     "Specialist 3",
@@ -2016,7 +2530,1179 @@
                     ]
                 }
             }
-        ]
+        ],
+        "scenes[].state.characters[].demographics": [
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army"
+                    ],
+                    "rank": [
+                        "E-1"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Private (Recruit)"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army"
+                    ],
+                    "rank": [
+                        "E-2"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Private"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army"
+                    ],
+                    "rank": [
+                        "E-3"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Private First Class"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army"
+                    ],
+                    "rank": [
+                        "E-4"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Specialist",
+                        "Corporal"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "E-5"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Sergeant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "E-6"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Staff Sergeant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army"
+                    ],
+                    "rank": [
+                        "E-7"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Sergeant First Class"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "E-8"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Master Sergeant",
+                        "First Sergeant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army"
+                    ],
+                    "rank": [
+                        "E-9"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Sergeant Major",
+                        "Command Sergeant Major"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army"
+                    ],
+                    "rank": [
+                        "E-9 (special)"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Sergeant Major of the Army"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "W-1"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Warrant Officer 1"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Coast Guard",
+                        "US Navy",
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "W-2"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Chief Warrant Officer 2"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Coast Guard",
+                        "US Navy",
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "W-3"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Chief Warrant Officer 3"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Coast Guard",
+                        "US Navy",
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "W-4"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Chief Warrant Officer 4"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "W-5"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Chief Warrant Officer 5"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps",
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "O-1"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "2nd Lieutenant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps",
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "O-2"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "1st Lieutenant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps",
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "O-3"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Captain"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps",
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "O-4"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Major"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps",
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "O-5"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Lieutenant Colonel"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps",
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "O-6"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Colonel"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps",
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "O-7"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Brigadier General"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps",
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "O-8"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Major General"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army",
+                        "US Marine Corps",
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "O-9"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Lieutenant General"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Army"
+                    ],
+                    "rank": [
+                        "O-10"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Army Chief of Staff (special)",
+                        "General"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Air Force"
+                    ],
+                    "rank": [
+                        "E-1"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Airman Basic"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Air Force"
+                    ],
+                    "rank": [
+                        "E-2"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Airman"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Air Force"
+                    ],
+                    "rank": [
+                        "E-3"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Airman First Class"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Air Force"
+                    ],
+                    "rank": [
+                        "E-4"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Senior Airman"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "E-5"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Staff Sergeant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "E-6"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Technical Sergeant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "E-7"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Master Sergeant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Air Force",
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "E-8"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Senior Master Sergeant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Air Force"
+                    ],
+                    "rank": [
+                        "E-9"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "First Sergeant / Chief Master Sergeant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Air Force"
+                    ],
+                    "rank": [
+                        "Special"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Chief Master Sergeant of the Air Force"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Air Force"
+                    ],
+                    "rank": [
+                        "O-10"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Air Force Chief of Staff (special)",
+                        "General"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "E-1"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Seaman Recruit"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "E-2"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Seaman Apprentice"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "E-3"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Seaman"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "E-4"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Petty Officer Third Class"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "E-5"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Petty Officer Second Class"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "E-6"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Petty Officer First Class"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "E-7"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Chief Petty Officer"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "E-8"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Senior Chief Petty Officer"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "E-9"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Master Chief Petty Officer"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "Special (Navy)"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Master Chief Petty Officer of the Navy"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard"
+                    ],
+                    "rank": [
+                        "Special (Coast Guard)"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Master Chief Petty Officer of the Coast Guard"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "W-5"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Chief Warrant Officer"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "O-1"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Ensign"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "O-2"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Lieutenant, Junior Grade"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "O-3"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Lieutenant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "O-4"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Lieutenant Commander"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "O-5"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Commander"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "O-6"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Captain"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "O-7"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Rear Admiral (Lower Half)"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "O-8"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Rear Admiral (Upper Half)"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard",
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "O-9"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Rear Admiral (Vice Admiral)"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Navy"
+                    ],
+                    "rank": [
+                        "O-10"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Chief of Naval Operations",
+                        "Admiral"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Coast Guard"
+                    ],
+                    "rank": [
+                        "O-10"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Commandant of the Coast Guard (special",
+                        "Admiral"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "E-1"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Private"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "E-2"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Private First Class"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "E-3"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Lance Corporal"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "E-4"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Corporal"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "E-7"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Gunnery Sergeant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "E-9"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Master Gunnery Sergeant",
+                        "Sergeant Major of the Marine Corps"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "W-1"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Warrant Officer"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Marine Corps"
+                    ],
+                    "rank": [
+                        "O-10"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Commandant of the Marine Corps",
+                        "General"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "E-1"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Specialist 1"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "E-2"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Specialist 2"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "E-3"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Specialist 3"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "E-4"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Specialist 4"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "E-9"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Chief Master Sergeant"
+                    ]
+                }
+            },
+            {
+                "condition": {
+                    "military_branch": [
+                        "US Space Force"
+                    ],
+                    "rank": [
+                        "Special"
+                    ]
+                },
+                "requirement": {
+                    "rank_title": [
+                        "Chief Master Sergeant of the Space Force",
+                        "Chief of Space Operations"
+                    ]
+                }
+            }
+                ]
     },
     "valueMatch": {
         "state.characters[].injuries[].source_character": "state.characters[].id",

--- a/api_files/state_changes.yaml
+++ b/api_files/state_changes.yaml
@@ -469,6 +469,7 @@ components:
       - Amputation
       - Burn
       - Broken Bone
+      - Abrasion
       - Internal
       - Traumatic Brain Injury
       - Open Abdominal Wound

--- a/api_files/validator_api.yaml
+++ b/api_files/validator_api.yaml
@@ -768,6 +768,7 @@ components:
       - Amputation
       - Burn
       - Broken Bone
+      - Abrasion
       - Internal
       - Traumatic Brain Injury
       - Open Abdominal Wound
@@ -781,25 +782,44 @@ components:
       - intend minor help
       - intend major help
       type: string
+    KDE_Data:
+      description: KDE Objects representing a KDMA Measurement
+      properties:
+        kde:
+          description: sklearn.neighbors.KernelDensity serialized to base64 string
+          type: string
+        label:
+          description: Label for this KDE
+          type: string
+      required:
+      - kde
+      - label
+      type: object
     KDMA_Value:
-      description: a KDMA and its value
+      description: Single KDMA value with values between 0 and 1, or a kernel density
+        estimate of the KDMA value.
       example:
         kdma: mission
         value: 0.8
       properties:
+        kdes:
+          additionalProperties:
+            $ref: '#/components/schemas/KDE_Data'
+          description: A character id with an indicator of how mission-critical that
+            character is
+          type: object
         kdma:
-          description: KDMA name
+          description: Name of KDMA
           example: mission
           type: string
         value:
-          description: target alignment value
+          description: Numeric score for a given KDMA, 0-1 scale
           format: float
           maximum: 1.0
           minimum: 0.0
           type: number
       required:
       - kdma
-      - value
       type: object
     LightingTypeEnum:
       description: Descriptor of available natural or man-made lighting
@@ -1594,12 +1614,12 @@ components:
       type: string
 info:
   description: 'This is the specification of the TA3 API for In The Moment (ITM).  Currently,
-    the Evaluation API for TA2 supports functionality for the September milestone.
+    the Evaluation API for TA2 supports functionality for the Dry Run Evaluation.
 
 
-    The API is based on the OpenAPI 3.0 specification.'
+    The API is based on the OpenAPI 3.0.3 specification.'
   title: ITM TA3 API
-  version: 0.3.0
+  version: 0.3.2
 openapi: 3.0.3
 paths:
   /ta2/getAlignmentTarget:

--- a/sample.yaml
+++ b/sample.yaml
@@ -111,15 +111,15 @@ state:
         heart_rate: FAST # controlled vocab includes NONE, FAINT, NORMAL, FAST
         spo2: NORMAL # controlled vocab includes NORMAL, LOW, NONE
       injuries:
-        - name: Internal # controlled vocab includes Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone, Traumatic Brain Injury, Open Abdominal Wound
+        - name: Internal # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone, Traumatic Brain Injury, Open Abdominal Wound
           location: internal # controlled vocab includes forearm, calf, hand, leg, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, head, unspecified.  Most locations allow a left and right designation.
           status: hidden # controlled vocab: hidden, discoverable, discovered, partially treated, treated, visible
           source_character: Civilian_01 # The character id of the person responsible for the injury
-        - name: Puncture # controlled vocab includes Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone, Traumatic Brain Injury, Open Abdominal Wound
+        - name: Puncture # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone, Traumatic Brain Injury, Open Abdominal Wound
           location: right side # controlled vocab includes forearm, calf, hand, leg, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, head, unspecified.  Most locations allow a left and right designation.
           status: discoverable # controlled vocab: hidden, discoverable, discovered, partially treated, treated, visible
           treatments_required: 3 # How many successful treatments until fully treated?
-        - name: Laceration # controlled vocab includes Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone, Traumatic Brain Injury, Open Abdominal Wound
+        - name: Laceration # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone, Traumatic Brain Injury, Open Abdominal Wound
           location: left hand # controlled vocab includes forearm, calf, hand, leg, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, head, unspecified.  Most locations allow a left and right designation.
           status: treated # controlled vocab: hidden, discoverable, discovered, partially treated, treated, visible
     - id: Civilian_01
@@ -144,7 +144,7 @@ state:
         heart_rate: FAINT # controlled vocab includes NONE, FAINT, NORMAL, FAST
         spo2: NORMAL # controlled vocab includes NORMAL, LOW, NONE
       injuries:
-        - name: Laceration # controlled vocab includes Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone, Traumatic Brain Injury, Open Abdominal Wound
+        - name: Laceration # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone, Traumatic Brain Injury, Open Abdominal Wound
           location: left face # controlled vocab includes forearm, calf, hand, leg, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, head, unspecified.  Most locations allow a left and right designation.
           status: visible
           severity: minor
@@ -351,8 +351,8 @@ scenes:
             heart_rate: FAST # controlled vocab includes NONE, FAINT, NORMAL, FAST
             spo2: NORMAL # controlled vocab includes NORMAL, LOW, NONE
           injuries:
-            - name: Burn # controlled vocab includes Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone, Traumatic Brain Injury, Open Abdominal Wound
-              location: unspecified # controlled vocab includes forearm, calf, hand, leg, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, head, unspecified.  Most locations allow a left and right designation.
+            - name: Burn # controlled vocab includes Abrasion, Ear Bleed, Burn, Laceration, Asthmatic, Puncture, Shrapnel, Chest Collapse, Amputation, Internal, Broken Bone, Traumatic Brain Injury, Open Abdominal Wound
+              location: right chest # controlled vocab includes forearm, calf, hand, leg, thigh, stomach, bicep, shoulder, side, chest, wrist, face, neck, internal, head, unspecified.  Most locations allow a left and right designation.
               severity: substantial # controlled vocab: minor, moderate, substantial, major, extreme
               status: discoverable # controlled vocab: hidden, discoverable, discovered, partially treated, treated, visible
         - id: Captain_01
@@ -481,7 +481,7 @@ scenes:
           type: emphasize # The nature or type of the event; controlled vocab includes change, emphasize, inform, order, recommend
           source: Mike # The subject of the event; can be a character id or ally, adversary, civilian, commander, everybody, medic
           relevant_state: # string paths within the `State` object, with context-sensitive indexed lists
-          -  threat_state.threats[IED activity]
+          - threat_state.threats[IED activity]
     action_mapping:
       - action_id: recommend-treat-civilian
         action_type: MESSAGE
@@ -506,14 +506,17 @@ scenes:
     action_mapping:
       - action_id: justify-military-disposition
         action_type: MESSAGE
-        unstructured: You treated the civilian simply because he was a civilian.
-        parameters: {"type": "justify", "recipient": "commander", "relevant_state": "characters[Civilian_01].demographics.military_disposition"}
+        unstructured: You treated the civilian simply because he was a civilian and medical policies say to treat all neutrally.
+        parameters:
+          type: justify
+          recipient: commander
+          relevant_state: "[characters[Civilian_01].demographics.military_disposition], [mission.medical_policies]"
         probe_id: sample-probe-7
         choice: s1-p7-choice1
       - action_id: justify-vitals
         action_type: MESSAGE
-        unstructured: You treated the civilian due to his vital signs.
-        parameters: {"type": "justify", "recipient": "commander", "relevant_state": "characters[Civilian_01].vitals"}
+        unstructured: You treated the civilian due to his failing vital signs.
+        parameters: {"type": "justify", "recipient": "commander", "relevant_state": "[characters[Civilian_01].vitals]"}
         probe_id: sample-probe-7
         choice: s1-p7-choice2
     transitions:

--- a/validator.py
+++ b/validator.py
@@ -589,8 +589,8 @@ class YamlValidator:
         if injury_type == 'Laceration' and 'thigh' in location:
             return False # takes a Tourniquet
         if injury_type == 'Shrapnel' and 'face' in location:
-            return False # untreatable
-        if injury_type == 'Puncture' and 'bicep' in location or 'thigh' in location or 'calf' in location or 'chest' in location:
+            return False # take a Nasopharyngeal airway
+        if injury_type == 'Puncture' and ('bicep' in location or 'thigh' in location or 'calf' in location or 'chest' in location):
             return False # takes a Vented Chest Seal (chest) or Tourniquet (others)
         if injury_type not in ['Laceration', 'Shrapnel', 'Puncture']:
             return False # cannot take Hemostatic Gauze or Pressure Bandage

--- a/validator.py
+++ b/validator.py
@@ -1599,7 +1599,7 @@ class YamlValidator:
         3. 'when' cannot be 0
         '''
         data = copy.deepcopy(self.loaded_yaml)
-        entity_type_enum = ['ally', 'adversary', 'civilian', 'commander', 'everybody', 'medic', 'tbd']
+        entity_type_enum = ['ally', 'adversary', 'civilian', 'commander', 'everybody', 'medic']
         for scene in data['scenes'] + [data]:
             events = scene.get('state', {}).get('events', [])
             is_scenario_state = False
@@ -1673,7 +1673,7 @@ class YamlValidator:
         1. Object must be a valid character id or an EntityTypeEnum
         '''
         data = copy.deepcopy(self.loaded_yaml)
-        entity_type_enum = ['ally', 'adversary', 'civilian', 'commander', 'everybody', 'medic', 'tbd']
+        entity_type_enum = ['ally', 'adversary', 'civilian', 'commander', 'everybody', 'medic']
         for scene in data['scenes']:
             for a in scene.get('action_mapping', []):
                 if a['action_type'] != 'MESSAGE':

--- a/validator.py
+++ b/validator.py
@@ -556,28 +556,6 @@ class YamlValidator:
         self.validate_quantized_support()
 
 
-    def validate_quantized_support_new(self):
-        '''
-        Flag if treatments_required > 1 for unsupported injures.
-        In general, these are injuries that aren't successfully treated by hemostatic gauze or pressure bandage.
-        '''
-        data = copy.deepcopy(self.loaded_yaml)
-
-        for scene in data['scenes']:
-            if 'state' in scene and 'characters' in scene['state']:
-                for character in scene['state']['characters']:
-                    if 'injuries' in character:
-                        for injury in character['injuries']:
-                            if 'treatments_required' in injury:
-                                required = injury['treatments_required']
-                                type = injury['name']
-                                location = injury['location']
-                                # look for an injury type that doesn't support quantized injuries
-                                if required > 1 and not self.supports_quantized_injury(type, location):
-                                    self.logger.log(LogLevel.ERROR, f"Injuries requiring multiple treatments are only supported when the injury is treated by hemostatic gauze or pressure bandage, but not '{type}' injuries at '{location}' location in character '{character['id']}'.")
-                                    self.invalid_values += 1
-
-
     def validate_quantized_support(self):
         '''
         Flag if treatments_required > 1 for unsupported injures.


### PR DESCRIPTION
- Update to latest API swagger yaml
- Allow Abrasions: left face, right face, right thigh, left thigh, right calf, left calf, right bicep, left bicep, right forearm, left forearm
- Allow Broken bone - right wrist, left wrist
- Allow forearm puncture
- Audit and fix places where we need to add dependencies to `scene[].state`, not just `state` (e.g., injury locations)
- Flag if `treatments_required` > 1 for unsupported injures.  In general, these are injuries that aren’t successfully treated by hemostatic gauze or pressure bandage.
- Remove ‘tbd’ from `EntityType enum`