### PR TITLE
Itm 554 post dre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ output/*
 participant-data/*
 test_yamls
 freeform_jsons
+extra_scripts
+dre_yamls
+jsons_from_yamls

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ In order for a yaml file to be considered "valid", the following conditions must
         * `breathing`
         * `heart_rate`
         * `spo2`
+        * `ambulatory`
     * `restricted_actions` cannot include `end_scene`
     * `session_complete` is a prohibited key in `scenario`
     * `scenario_complete` is a prohibited key in `state`
@@ -208,7 +209,7 @@ Any supply name placed in this array will be excluded from the allowed supplies 
 #### Eval Mode
 When not running in training mode (-t), additional checks are implemented:
 * No supplies or treatments are allowed that are not in the simulator. Put the names of these treatments in the trainingOnlySupplies array in dependencies.json
-* No more than 8 injuries of types (puncture, burn, or laceration) may be given to a character at a time
+* No more than 12 injuries of types (abrasion, puncture, burn, or laceration) may be given to a character at a time
 
 
 #### Injury/Location Matches
@@ -220,12 +221,12 @@ When not running in training mode (-t), additional checks are implemented:
 | `Ear Bleed` | `left face` |
 | `Asthmatic` | `internal` |
 | `Abrasion` | `left face`, `right face`, `left thigh`, `right thigh`, `left calf`, `right calf`, `left bicep`, `right bicep`, `left forearm`, `right forearm` |
-| `Laceration` | `left face`, `left forearm`, `right forearm`, `left stomach`, `left thigh`, `right thigh`, `left calf`, `right calf`, `left wrist`, `right wrist` |
+| `Laceration` | `left face`, `left forearm`, `right forearm`, `left stomach`, `left thigh`, `right thigh`, `left calf`, `right calf`, `left hand`, `right hand` |
 | `Puncture` | `left neck`, `right neck`, `left bicep`, `right bicep`, `left forearm`, `right forearm`, `left shoulder`, `right shoulder`, `left stomach`, `right stomach`, `left side`, `right side`, `left thigh`, `right thigh`, `left chest`, `right chest`, `center chest`, `left calf`, `right calf` |
-| `Shrapnel` | `left face`, `right face`, `left calf`, `right calf` |
+| `Shrapnel` | `right face`, `left calf`, `right calf` |
 | `Chest Collapse` | `left chest`, `right chest` |
 | `Amputation` | `left wrist`, `right wrist`, `left calf`, `right calf`, `left thigh`, `right thigh` |
-| `Burn` | `right forearm`, `left forearm`, `right calf`, `left calf`, `right thigh`, `left thigh`, `right side`, `left side`, `right chest`, `left chest`, `neck`, `right bicep`, `left biecp` |
+| `Burn` | `right forearm`, `left forearm`, `right calf`, `left calf`, `right thigh`, `left thigh`, `right side`, `left side`, `right chest`, `left chest`, `neck`, `right bicep`, `left bicep` |
 | `Broken Bone` | `right leg`, `left leg`, `right shoulder`, `left shoulder`, `right wrist`, `left wrist` |
 | `Internal` | `internal`, `unspecified` | 
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ options:
   -h, --help                Show this help message and exit.
   -f PATH, --filepath PATH  The path to the yaml file. Required if -u is not specified.
   -u, --update              Switch to update the api files or not. Required if -f is not specified.
-  -t, --train               Validate a training scenario yaml.```
+  -t, --train               Validate a training scenario yaml.
+  ```
 
 ## API Changes
 - When the Swagger API changes, make sure you upload the newest version as `api.yaml` to the `api_files` directory.
@@ -157,6 +158,7 @@ If persist_characters is false:
     * `scenes[n].transitions.character_vitals[].character_id`: `scenes[n].state.characters[].id`,
     * `scenes[n].action_mapping[].probe_conditions.character_vitals[].character_id`: `scenes[n].state.characters[].id`
     * `scenes[n].action_mapping[].action_conditions.character_vitals[].character_id`: `scenes[n].state.characters[].id`
+
 Otherwise, complete the same checks, but match it up against all characters defined throughout the scenario file. Note that this may give some false validity, as a character may end up being used before it is defined. Please be cautious when defining characters and using persist_characters. 
 In addition, if a character is removed anywhere throughout the scenario, a warning will be issued. Please make sure that your branching scenes do not cause a situation where a character has been removed and then used.
 
@@ -196,7 +198,7 @@ Any supply name placed in this array will be excluded from the allowed supplies 
 * `when` cannot be 0
 
 
-#### Injury treatment rules
+#### Injury Treatment Rules
 * An injury may not be partially treated
 * An injury's treatments_applied property must either be 0 or equal to treatments_required
 * An injury's status must be 'treated' iff treatments_applied == treatments_required
@@ -216,7 +218,8 @@ When not running in training mode (-t), additional checks are implemented:
 
 
 #### Injury/Location Matches
-* Injuries are only allowed to have specific locations. Please follow the table to create valid matches. 
+* Injuries are only allowed to have specific locations. Please follow the table to create valid matches:
+
 | Injury name | Allowed Locations |
 | --- | --- |
 | `Traumatic Brain Injury` | `head` |

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Any supply name placed in this array will be excluded from the allowed supplies 
 * If the scene is the first scene, `scenes[].state` should _not_ be provided
 * No blanket can appear on the character at the start. 
 * Quantized injuries (where `treatments_required` > 1) aren't supported for injuries that aren't successfully treated by hemostatic gauze or pressure bandage.
+* No more than one injury can appear on the same limb or same side of the face
+* APPLY_TREATMENT actions must not contain locations that do not match the location of an injury on the specified character
 
 #### Message/Event Rules
 * `source` is recommended for all events
@@ -198,6 +200,7 @@ Any supply name placed in this array will be excluded from the allowed supplies 
 * An injury may not be partially treated
 * An injury's treatments_applied property must either be 0 or equal to treatments_required
 * An injury's status must be 'treated' iff treatments_applied == treatments_required
+* An injury's status must be 'treated' if a relateed injury's status is treated (i.e. if R Bicep Puncture is treated, R Forearm Puncture must be treated)
 
 
 #### Unseen Characters

--- a/api_files/dependencies.json
+++ b/api_files/dependencies.json
@@ -559,7 +559,6 @@
             },
             "Shrapnel": {
                 "state.characters[].injuries[].location": [
-                    "left face",
                     "right face",
                     "left calf",
                     "right calf"
@@ -689,7 +688,6 @@
             },
             "Shrapnel": {
                 "scenes[].state.characters[].injuries[].location": [
-                    "left face",
                     "right face",
                     "left calf",
                     "right calf"

--- a/api_files/generator.py
+++ b/api_files/generator.py
@@ -59,10 +59,11 @@ class ApiGenerator:
         # validator requires all vitals properties to be specified
         required_vitals = new_api['components']['schemas']['Vitals']['required'] if 'required' in new_api['components']['schemas']['Vitals'] else []
         required_vitals.append('avpu')
+        required_vitals.append('ambulatory')
         required_vitals.append('mental_status')
         required_vitals.append('breathing')
         required_vitals.append('heart_rate')
-        required_vitals.append('Spo2')
+        required_vitals.append('spo2')
         new_api['components']['schemas']['Vitals']['required'] = required_vitals
 
         # create a new enum for restricted_actions that doesn't include END_SCENE

--- a/api_files/state_changes.yaml
+++ b/api_files/state_changes.yaml
@@ -1071,10 +1071,11 @@ components:
           $ref: '#/components/schemas/BloodOxygenEnum'
       required:
       - avpu
+      - ambulatory
       - mental_status
       - breathing
       - heart_rate
-      - Spo2
+      - spo2
       type: object
     WeatherTypeEnum:
       description: Descriptor of the scenario weather

--- a/api_files/validator_api.yaml
+++ b/api_files/validator_api.yaml
@@ -1598,10 +1598,11 @@ components:
           $ref: '#/components/schemas/BloodOxygenEnum'
       required:
       - avpu
+      - ambulatory
       - mental_status
       - breathing
       - heart_rate
-      - Spo2
+      - spo2
       type: object
     WeatherTypeEnum:
       description: Descriptor of the scenario weather

--- a/validator.py
+++ b/validator.py
@@ -1799,7 +1799,11 @@ class YamlValidator:
                 if action.get('action_type') == 'APPLY_TREATMENT' and action.get('character_id', None) is not None and action.get('parameters', {}).get('location', None) is not None:
                     loc = action.get('parameters').get('location')
                     if action.get('parameters').get('treatment') in ['Epi Pen', 'Blanket', 'Blood', 'Pain Medications', 'IV Bag', 'Fentanyl Lollipop']:
-                          continue
+                        continue
+                    if action.get('parameters').get('treatment') == 'Nasopharyngeal airway' and loc not in ['right face', 'left face']:
+                        self.logger.log(LogLevel.ERROR, f"Scene '{scene['id']}' has APPLY_TREATMENT action with location '{loc}', but treatment type '{action.get('parameters').get('treatment')}' must have location of 'left face' or 'right face'.")
+                        self.invalid_values += 1   
+                        continue
                     if loc == 'internal' or loc == 'unspecified':
                         self.logger.log(LogLevel.ERROR, f"Scene '{scene['id']}' has APPLY_TREATMENT action with location '{loc}', but that location is invalid for the treatment type '{action.get('parameters').get('treatment')}'.")
                         self.invalid_values += 1   

--- a/validator.py
+++ b/validator.py
@@ -1866,7 +1866,8 @@ class YamlValidator:
                 # check that locations that can only have one injury do
                 for loc in single_only:
                     if len(single_only[loc]) > 1:
-                        self.logger.log(LogLevel.ERROR, f"Character '{c['id']}' has multiple injuries at the same location: '{loc}'.")
+                        scene_str = f"in scene '{scene.get('id')}'" if scene.get('id') is not None else 'at the state level'
+                        self.logger.log(LogLevel.ERROR, f"Character '{c['id']}' has multiple injuries at the same location: '{loc}' {scene_str}.")
                         self.invalid_values += 1   
                 
                 for i in injs:

--- a/validator.py
+++ b/validator.py
@@ -187,6 +187,10 @@ class YamlValidator:
         '''
         paths = []
         scene = self.get_scene_by_id(scene_id)
+        if scene is None:
+            self.logger.log(LogLevel.ERROR, f"Key 'next_scene' has value {scene_id}, which is not a valid scene.")
+            self.invalid_values += 1
+            return path
         next_scene_id = None
         if type(scene_id) is int and int(scene_id) >= 0:
             next_scene_id = int(scene_id) + 1
@@ -325,8 +329,8 @@ class YamlValidator:
         if level_name == 'characters':
             if 'injuries' in to_validate:
                 injury_count = sum(1 for injury in to_validate['injuries'] if injury['name'] not in ['Ear Bleed', 'Asthmatic', 'Internal'] and 'Broken' not in injury['name'])
-                if injury_count > 8 and not self.train_mode:
-                    self.logger.log(LogLevel.ERROR, f"Character '{to_validate.get('name')}' has {injury_count} 'masked' injuries (punctures, lacerations, burns), which exceeds the maximum of 8 allowed in the simulation.")
+                if injury_count > 12 and not self.train_mode:
+                    self.logger.log(LogLevel.ERROR, f"Character '{to_validate.get('name')}' has {injury_count} 'masked' injuries (abrasions, punctures, lacerations, burns), which exceeds the maximum of 12 allowed in the simulation.")
     
 
     def determine_first_scene(self, data):
@@ -339,7 +343,10 @@ class YamlValidator:
         if first_scene_id is None:
             return scenes[0]
         else:
-            return self.get_scene_by_id(first_scene_id)
+            first_scene = self.get_scene_by_id(first_scene_id)
+            if first_scene is None:
+                return scenes[0]
+            return first_scene
         
 
     def get_scene_by_id(self, scene_id):
@@ -554,6 +561,8 @@ class YamlValidator:
         self.validate_messages()
         self.are_all_scenes_reachable()
         self.validate_quantized_support()
+        self.validate_treatments_have_injuries()
+        self.validate_injury_sets()
 
 
     def validate_quantized_support(self):
@@ -1154,11 +1163,11 @@ class YamlValidator:
                     if found:
                         # found in at least one path, but not found in at least one path - warning
                         self.warning_count += 1
-                        self.logger.log(LogLevel.WARN, f"There might be an invalid action in scene '{scene['id']}'. A pulse oximeter must be available in order to have 'action type' equal to 'CHECK_BLOOD_OXYGEN' OR 'CHECK_ALL_VITALS', but in at least one branching path, the pulse oximeter is missing. Please ensure that a pulse oximeter is always available for this scene.")
+                        self.logger.log(LogLevel.WARN, f"There might be an invalid action in scene '{scene['id']}'. A pulse oximeter must be available in order to have 'action type' equal to 'CHECK_BLOOD_OXYGEN', but in at least one branching path, the pulse oximeter is missing. Please ensure that a pulse oximeter is always available for this scene.")
                     else:
                         # not found in any paths
                         self.invalid_values += 1
-                        self.logger.log(LogLevel.ERROR, f"There is an invalid action in scene '{scene['id']}'. A pulse oximeter must be available in order to have 'action type' equal to 'CHECK_BLOOD_OXYGEN' OR 'CHECK_ALL_VITALS' but is never available through any branching path. Please ensure that a pulse oximeter is always available for this scene.")
+                        self.logger.log(LogLevel.ERROR, f"There is an invalid action in scene '{scene['id']}'. A pulse oximeter must be available in order to have 'action type' equal to 'CHECK_BLOOD_OXYGEN' but is never available through any branching path. Please ensure that a pulse oximeter is always available for this scene.")
                     break
 
 
@@ -1427,6 +1436,34 @@ class YamlValidator:
                         chars['seen'].append(x['id'])
             chars['possible'] = [chars['possible']]
         return chars
+
+
+    def get_char_injuries_in_scene(self, data, scene_id, char_id):
+        '''
+        Gets a character's injuries in a given scene
+        '''
+        def get_basic_chars(scene):
+            characters = {}
+            for c in scene.get('state', {}).get('characters', []):
+                characters[c['id']] = c.get('injuries', [])
+            return characters
+
+        first_scene_id = self.determine_first_scene(data)['id']
+        injuries = []
+        all_segs = self.get_branch_segments_for_scene(scene_id)
+        segments = all_segs['segments']
+        for segment in segments:
+            for sid in segment:
+                if sid == first_scene_id:
+                    # get scenario characters from first scene
+                    injuries += get_basic_chars(data).get(char_id)
+                else:
+                    # modify allowed characters up to this point
+                    scene = self.get_scene_by_id(sid)
+                    tmp_inj = get_basic_chars(scene).get(char_id)
+                    if tmp_inj is not None:
+                        injuries = tmp_inj
+        return injuries
 
 
     def get_supplies_in_scene(self, data, scene_id):
@@ -1748,6 +1785,104 @@ class YamlValidator:
             if scene['id'] not in all_scenes_hit:
                 self.logger.log(LogLevel.WARN, f"Scene '{scene['id']}' is unreachable.")
                 self.warning_count += 1     
+
+
+    def validate_treatments_have_injuries(self):
+        '''
+        Checks APPLY_TREATMENT actions to ensure that the character has an injury at
+        the specified location to match the action's location.
+        '''
+        data = copy.deepcopy(self.loaded_yaml)
+
+        for scene in data['scenes']:
+            for action in scene['action_mapping']:
+                if action.get('action_type') == 'APPLY_TREATMENT' and action.get('character_id', None) is not None and action.get('parameters', {}).get('location', None) is not None:
+                    loc = action.get('parameters').get('location')
+                    char = action.get('character_id')
+                    injuries = self.get_char_injuries_in_scene(data, scene['id'], char)
+                    found = False
+                    for i in injuries:
+                        if i.get('location') == loc:
+                            found = True
+                            break
+                    if not found:
+                        self.logger.log(LogLevel.ERROR, f"Scene '{scene['id']}' has APPLY_TREATMENT action for '{char}' with location '{loc}', but that character has no injury at that location during this scene.")
+                        self.invalid_values += 1   
+
+
+    def validate_injury_sets(self):
+        '''
+        Validates that all injuries assigned to a character can coexist.
+        1. Ensure if an injury is pretreated with a tourniquet, tourniquet-treatable injuries lower on the same region are also pretreated
+        2. Ensure no impossible injury combinations (i.e. thigh amputation and any leg injuries on the same leg)
+        '''
+        data = copy.deepcopy(self.loaded_yaml)
+        '''
+        Flag impossible injury combinations, e.g.,
+
+        Thigh amputation and any other thigh, calf, or leg injury on the same leg;
+
+        Thighs, calves, biceps, wrists, and forearms can only have a single injury (except for burn? when are burns allowed?); and
+
+        A given side of the face can only have one of shrapnel, laceration, or abrasion.
+
+        '''
+        for scene in data['scenes'] + [{'state': data['state']}]:
+            for c in scene.get('state', {}).get('characters', []):
+                injs = c.get('injuries', [])
+                required_pretreated = []
+                has_left_thigh_amp = False
+                has_right_thigh_amp = False
+                single_only = {'left thigh': [], 'right thigh': [], 'left calf': [], 'right calf': [], 'left wrist': [], 
+                               'right wrist': [], 'left forearm': [], 'right forearm': [], 'left face': [], 'right face': []}
+                # get everything that must be pretreated if it exists, as well as a list of injuries that cannot be allowed given the existence of certain others
+                for i in injs:
+                    name = i.get('name')
+                    loc = i.get('location')
+                    side = loc.split(' ')[0]
+                    if loc in single_only and name not in ['Burn', 'Ear Bleed']:
+                        single_only[loc].append(name)
+                    if i.get('status') == 'treated':
+                        if name == 'Puncture':
+                            if 'bicep' in loc:
+                                required_pretreated.append({'name': 'Puncture', 'location': f'{side} forearm', 'reason': f'{side} bicep puncture'})
+                                required_pretreated.append({'name': 'Amputation', 'location': f'{side} wrist', 'reason': f'{side} bicep puncture'})
+                            if 'thigh' in loc:
+                                required_pretreated.append({'name': 'Puncture', 'location': f'{side} calf', 'reason': f'{side} thigh puncture'})
+                                required_pretreated.append({'name': 'Amputation', 'location': f'{side} calf', 'reason': f'{side} thigh puncture'})
+                            if 'forearm' in loc:
+                                required_pretreated.append({'name': 'Amputation', 'location': f'{side} wrist', 'reason': f'{side} forearm puncture'})
+                        if name == 'Laceration':
+                            if 'thigh' in loc:
+                                required_pretreated.append({'name': 'Puncture', 'location': f'{side} calf', 'reason': f'{side} thigh laceration'})
+                                required_pretreated.append({'name': 'Amputation', 'location': f'{side} calf', 'reason': f'{side} thigh laceration'})
+                        if name == 'Amputation' and 'thigh' in loc:
+                            if side == 'left':
+                                has_left_thigh_amp = True
+                            else:
+                                has_right_thigh_amp = True
+                # check that locations that can only have one injury do
+                for loc in single_only:
+                    if len(single_only[loc]) > 1:
+                        self.logger.log(LogLevel.ERROR, f"Character '{c['id']}' has multiple injuries at the same location: '{loc}'.")
+                        self.invalid_values += 1   
+                
+                for i in injs:
+                    name = i.get('name')
+                    loc = i.get('location')
+                    # check for invalid leg injuries due to amputations
+                    if has_left_thigh_amp and loc in ['left thigh', 'left calf'] and not (loc == 'left thigh' and name == 'Amputation'):
+                        self.logger.log(LogLevel.ERROR, f"Character '{c['id']}' has injury '{name}' at location '{loc}', but also has a left thigh amputation. These injuries are incompatible.")
+                        self.invalid_values += 1   
+                    if has_right_thigh_amp and loc in ['right thigh', 'right calf'] and not (loc == 'right thigh' and name == 'Amputation'):
+                        self.logger.log(LogLevel.ERROR, f"Character '{c['id']}' has injury '{name}' at location '{loc}', but also has a right thigh amputation. These injuries are incompatible.")
+                        self.invalid_values += 1  
+                    # check if all required pretreated are pretreated
+                    for x in required_pretreated:
+                        if x['name'] == name and x['location'] == loc:
+                            if i.get('status') != 'treated':
+                                self.logger.log(LogLevel.ERROR, f"Character '{c['id']}' has injury '{name}' at location '{loc}' with status '{i.get('status')}', but the status must be 'treated' becausse injury '{x['reason']}' is treated.")
+                                self.invalid_values += 1   
 
 
 if __name__ == '__main__':

--- a/validator.py
+++ b/validator.py
@@ -1798,8 +1798,12 @@ class YamlValidator:
             for action in scene['action_mapping']:
                 if action.get('action_type') == 'APPLY_TREATMENT' and action.get('character_id', None) is not None and action.get('parameters', {}).get('location', None) is not None:
                     loc = action.get('parameters').get('location')
-                    if loc == 'internal' and action.get('parameters').get('treatment') in ['Blood', 'Pain Medications', 'Nasopharyngeal airway', 'IV Bag', 'Fentanyl Lollipop']:
+                    if action.get('parameters').get('treatment') in ['Epi Pen', 'Blanket', 'Blood', 'Pain Medications', 'IV Bag', 'Fentanyl Lollipop']:
                           continue
+                    if loc == 'internal' or loc == 'unspecified':
+                        self.logger.log(LogLevel.ERROR, f"Scene '{scene['id']}' has APPLY_TREATMENT action with location '{loc}', but that location is invalid for the treatment type '{action.get('parameters').get('treatment')}'.")
+                        self.invalid_values += 1   
+                        continue
                     char = action.get('character_id')
                     injuries = self.get_char_injuries_in_scene(data, scene['id'], char)
                     found = False


### PR DESCRIPTION
- Remove left face from Shrapnel.
- Fix Warning message in is_pulse_oximeter_configured not to include CHECK_ALL_VITALS.
- Fix typo in README: left biecp
- Flag when ambulatory and spo2 is missing from a character vitals (when unseen is not True).
- Flag certain invalid treatment/location combinations.
- Increase injury limit to 12.
- Don’t crash when first_scene or next_scene points to a non-existent scene id (log Error instead).
- Flag if an APPLY_TREATMENT action mapping lists a location, but there is no injury for the specified character at that injury.
- Change right wrist and left wrist Lacerations to right hand and left hand in "Injury/Location Matches" section of README.
- Flag when there are pretreated upper arm/leg injuries, but lower region of the same arm/leg is not pretreated (when the treatment is a tourniquet).  e.g.:
  - Flag if bicep puncture is pretreated, but forearm puncture is not;
  - Flag if bicep puncture is pretreated, but wrist amputation is not;
  - Flag if forearm puncture is pretreated, but wrist amputation is not;
  - Flag if thigh puncture is pretreated, but calf puncture is not;
  - Flag if thigh puncture is pretreated, but shin amputation is not;
  - Flag if thigh laceration is pretreated, but calf puncture is not; and
  - Flag if thigh laceration is pretreated, but shin amputation is not.
- Flag impossible injury combinations, e.g.,
  - Thigh amputation and any other thigh, calf, or leg injury on the same leg;
  - Thighs, calves, biceps, wrists, and forearms can only have a single injury); and
  - A given side of the face can only have one of shrapnel, laceration, or abrasion.